### PR TITLE
[HOTSPOT-65] 데이터 사용량 집계 Consumer 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
 
 	// DB (PostgreSQL)
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/hotspot/seed/SeedRunner.java
+++ b/src/main/java/hotspot/seed/SeedRunner.java
@@ -22,17 +22,21 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.StringUtils;
 
+/**
+ * 로컬 Redis에 정책/한도 시드 데이터를 적재하는 전용 실행기
+ */
 @SpringBootApplication
 public class SeedRunner {
+
     private static final int PIPELINE_BATCH_SIZE = 1000;
 
-    // ?�드 ?�용 ?�플리�??�션 진입??
     public static void main(String[] args) {
+        // SeedRunner 단독 실행 진입점
         SpringApplication.run(SeedRunner.class, args);
     }
 
-    // Redis 초기?????�체 ?�드 ?�업???�서?��??�행
     @Bean
+    // 애플리케이션 시작 시 시드 전체를 순서대로 수행
     CommandLineRunner run(JdbcTemplate jdbc, StringRedisTemplate redis) {
         return ignored -> {
             deleteByPattern(redis, "limit:sub:*");
@@ -63,12 +67,11 @@ public class SeedRunner {
         };
     }
 
-    // Redis ?�?��? API ?�출??UTF-8 바이??변??
     private static byte[] b(String s) {
         return s.getBytes(StandardCharsets.UTF_8);
     }
 
-    // ?�턴??맞는 ?��? 조회???�괄 ??��?�다(?�영 ?�?�량 ?�용 주의)
+    // 패턴에 해당하는 Redis 키를 일괄 삭제
     private static void deleteByPattern(StringRedisTemplate redis, String pattern) {
         var keys = redis.keys(pattern);
         if (keys != null && !keys.isEmpty()) {
@@ -76,7 +79,7 @@ public class SeedRunner {
         }
     }
 
-    // 구독-?�금???�보�??�어 개인 ?�도(limit:sub:{subId})�?채�?
+    // 구독 플랜 한도(limit:sub)를 적재
     private void seedPlanLimit(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT s.sub_id AS sub_id,
@@ -129,7 +132,7 @@ public class SeedRunner {
         });
     }
 
-    // 가�??�보�??�어 가�??�도(limit:family:{familyId})�?채�?
+    // 가족 풀 한도(limit:family)를 적재
     private void seedFamilyLimit(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT DISTINCT fs.family_id,
@@ -153,7 +156,7 @@ public class SeedRunner {
     private record FamilyLimitRow(long familyId, long familyLimitKb) {
     }
 
-    // 가�?구성???�덱???�선?�위/개별 가�??�도 ?��? ?�성
+    // 가족 구성원별 한도/우선순위 및 인덱스를 적재
     private void seedFamilySubLimitPriorityAndIndexes(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT family_id,
@@ -190,7 +193,7 @@ public class SeedRunner {
     private record FamilySubRow(long familyId, long subId, int priority, long dataLimitKb) {
     }
 
-    // ?�물 ?�이?�로 gift ?�도/?�덱?��? ?�공???�용?�을 ?�재
+    // 선물 데이터 한도와 기부자 사용량을 초기화
     private void seedPresentsAndDonorUsage(
         JdbcTemplate jdbc,
         StringRedisTemplate redis
@@ -268,7 +271,7 @@ public class SeedRunner {
         return appId;
     }
 
-    // 반복??차단 ?�책(SCHEDULED)??block:repeat???�재
+    // 반복 차단 정책(block:repeat) 적재
     private void seedBlockRepeat(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT ps.sub_id,
@@ -362,7 +365,7 @@ public class SeedRunner {
         };
     }
 
-    // 기간??차단 ?�책(ONCE)??block:time???�재
+    // 기간 차단 정책(block:time) 적재
     private void seedBlockTime(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT ps.sub_id,
@@ -437,7 +440,7 @@ public class SeedRunner {
         }
     }
 
-    // 즉시 차단 ?�책(IMMEDIATE)??block:immediate???�재
+    // 즉시 차단 정책(block:immediate) 적재
     private void seedBlockImmediate(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT s.sub_id
@@ -453,7 +456,7 @@ public class SeedRunner {
         });
     }
 
-    // ??차단 목록??block:app:{subId} ?�트�??�재
+    // 앱 차단 목록(block:app)을 적재
     private void seedBlockApp(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT bss.sub_id,
@@ -477,4 +480,3 @@ public class SeedRunner {
     private record BlockAppRow(long subId, String appId) {
     }
 }
-

--- a/src/main/java/hotspot/seed/SeedRunner.java
+++ b/src/main/java/hotspot/seed/SeedRunner.java
@@ -1,4 +1,4 @@
-package hotspot.worker.apps;
+package hotspot.seed;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -26,12 +26,12 @@ import org.springframework.util.StringUtils;
 public class SeedRunner {
     private static final int PIPELINE_BATCH_SIZE = 1000;
 
-    // 시드 전용 애플리케이션 진입점
+    // ?�드 ?�용 ?�플리�??�션 진입??
     public static void main(String[] args) {
         SpringApplication.run(SeedRunner.class, args);
     }
 
-    // Redis 초기화 후 전체 시드 작업을 순서대로 수행
+    // Redis 초기?????�체 ?�드 ?�업???�서?��??�행
     @Bean
     CommandLineRunner run(JdbcTemplate jdbc, StringRedisTemplate redis) {
         return ignored -> {
@@ -63,12 +63,12 @@ public class SeedRunner {
         };
     }
 
-    // Redis 저수준 API 호출용 UTF-8 바이트 변환
+    // Redis ?�?��? API ?�출??UTF-8 바이??변??
     private static byte[] b(String s) {
         return s.getBytes(StandardCharsets.UTF_8);
     }
 
-    // 패턴에 맞는 키를 조회해 일괄 삭제한다(운영 대용량 사용 주의)
+    // ?�턴??맞는 ?��? 조회???�괄 ??��?�다(?�영 ?�?�량 ?�용 주의)
     private static void deleteByPattern(StringRedisTemplate redis, String pattern) {
         var keys = redis.keys(pattern);
         if (keys != null && !keys.isEmpty()) {
@@ -76,7 +76,7 @@ public class SeedRunner {
         }
     }
 
-    // 구독-요금제 정보를 읽어 개인 한도(limit:sub:{subId})를 채움
+    // 구독-?�금???�보�??�어 개인 ?�도(limit:sub:{subId})�?채�?
     private void seedPlanLimit(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT s.sub_id AS sub_id,
@@ -129,7 +129,7 @@ public class SeedRunner {
         });
     }
 
-    // 가족 정보를 읽어 가족 한도(limit:family:{familyId})를 채움
+    // 가�??�보�??�어 가�??�도(limit:family:{familyId})�?채�?
     private void seedFamilyLimit(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT DISTINCT fs.family_id,
@@ -153,7 +153,7 @@ public class SeedRunner {
     private record FamilyLimitRow(long familyId, long familyLimitKb) {
     }
 
-    // 가족 구성원 인덱스/우선순위/개별 가족 한도 키를 생성
+    // 가�?구성???�덱???�선?�위/개별 가�??�도 ?��? ?�성
     private void seedFamilySubLimitPriorityAndIndexes(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT family_id,
@@ -190,7 +190,7 @@ public class SeedRunner {
     private record FamilySubRow(long familyId, long subId, int priority, long dataLimitKb) {
     }
 
-    // 선물 데이터로 gift 한도/인덱스와 제공자 사용량을 적재
+    // ?�물 ?�이?�로 gift ?�도/?�덱?��? ?�공???�용?�을 ?�재
     private void seedPresentsAndDonorUsage(
         JdbcTemplate jdbc,
         StringRedisTemplate redis
@@ -268,7 +268,7 @@ public class SeedRunner {
         return appId;
     }
 
-    // 반복형 차단 정책(SCHEDULED)을 block:repeat에 적재
+    // 반복??차단 ?�책(SCHEDULED)??block:repeat???�재
     private void seedBlockRepeat(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT ps.sub_id,
@@ -362,7 +362,7 @@ public class SeedRunner {
         };
     }
 
-    // 기간형 차단 정책(ONCE)을 block:time에 적재
+    // 기간??차단 ?�책(ONCE)??block:time???�재
     private void seedBlockTime(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT ps.sub_id,
@@ -437,7 +437,7 @@ public class SeedRunner {
         }
     }
 
-    // 즉시 차단 정책(IMMEDIATE)을 block:immediate에 적재
+    // 즉시 차단 ?�책(IMMEDIATE)??block:immediate???�재
     private void seedBlockImmediate(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT s.sub_id
@@ -453,7 +453,7 @@ public class SeedRunner {
         });
     }
 
-    // 앱 차단 목록을 block:app:{subId} 세트로 적재
+    // ??차단 목록??block:app:{subId} ?�트�??�재
     private void seedBlockApp(JdbcTemplate jdbc, StringRedisTemplate redis) {
         String sql = """
             SELECT bss.sub_id,
@@ -477,3 +477,4 @@ public class SeedRunner {
     private record BlockAppRow(long subId, String appId) {
     }
 }
+

--- a/src/main/java/hotspot/worker/common/config/redis/RedisLuaConfig.java
+++ b/src/main/java/hotspot/worker/common/config/redis/RedisLuaConfig.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 
+/**
+ * Redis Lua 스크립트 빈 설정
+ */
 @Configuration
 public class RedisLuaConfig {
 
@@ -19,4 +22,12 @@ public class RedisLuaConfig {
         return script;
     }
 
+    // 사용량 집계 Lua Script
+    @Bean
+    public DefaultRedisScript<List> usageAtomicScript() {
+        DefaultRedisScript<List> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/usage_atomic.lua"));
+        script.setResultType(List.class);
+        return script;
+    }
 }

--- a/src/main/java/hotspot/worker/consumer/config/KafkaConsumerConfig.java
+++ b/src/main/java/hotspot/worker/consumer/config/KafkaConsumerConfig.java
@@ -8,6 +8,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -50,8 +51,11 @@ public class KafkaConsumerConfig {
 
     // UsageEvent 역직렬화를 위한 ConsumerFactory
     @Bean
-    public ConsumerFactory<String, UsageEvent> consumerFactory(KafkaProperties props) {
-        Map<String, Object> cfg = new HashMap<>(props.buildConsumerProperties());
+    public ConsumerFactory<String, UsageEvent> consumerFactory(
+            KafkaProperties props,
+            SslBundles sslBundles
+    ) {
+        Map<String, Object> cfg = new HashMap<>(props.buildConsumerProperties(sslBundles));
         cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
 
@@ -64,8 +68,11 @@ public class KafkaConsumerConfig {
 
     // 알림 이벤트 발행용 ProducerFactory
     @Bean
-    public ProducerFactory<String, UsageAlertEvent> producerFactory(KafkaProperties props) {
-        Map<String, Object> cfg = new HashMap<>(props.buildProducerProperties());
+    public ProducerFactory<String, UsageAlertEvent> producerFactory(
+            KafkaProperties props,
+            SslBundles sslBundles
+    ) {
+        Map<String, Object> cfg = new HashMap<>(props.buildProducerProperties(sslBundles));
         cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         cfg.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);

--- a/src/main/java/hotspot/worker/consumer/config/KafkaConsumerConfig.java
+++ b/src/main/java/hotspot/worker/consumer/config/KafkaConsumerConfig.java
@@ -1,0 +1,82 @@
+package hotspot.worker.consumer.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+import hotspot.worker.consumer.schema.UsageAlertEvent;
+import hotspot.worker.consumer.schema.UsageEvent;
+
+/**
+ * Consumer 전용 Kafka 설정 클래스
+ */
+@Configuration
+public class KafkaConsumerConfig {
+
+    // 수동 ACK와 재시도 정책을 적용한 리스너 컨테이너 팩토리
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, UsageEvent> kafkaListenerContainerFactory(
+            ConsumerFactory<String, UsageEvent> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, UsageEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+
+        ExponentialBackOff backOff = new ExponentialBackOff(500L, 2.0);
+        backOff.setMaxInterval(10_000L);
+        backOff.setMaxElapsedTime(60_000L);
+        factory.setCommonErrorHandler(new DefaultErrorHandler(backOff));
+        return factory;
+    }
+
+    // UsageEvent 역직렬화를 위한 ConsumerFactory
+    @Bean
+    public ConsumerFactory<String, UsageEvent> consumerFactory(KafkaProperties props) {
+        Map<String, Object> cfg = new HashMap<>(props.buildConsumerProperties());
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        JsonDeserializer<UsageEvent> valueDeserializer = new JsonDeserializer<>(UsageEvent.class);
+        valueDeserializer.addTrustedPackages("*");
+        valueDeserializer.setUseTypeHeaders(false);
+
+        return new DefaultKafkaConsumerFactory<>(cfg, new StringDeserializer(), valueDeserializer);
+    }
+
+    // 알림 이벤트 발행용 ProducerFactory
+    @Bean
+    public ProducerFactory<String, UsageAlertEvent> producerFactory(KafkaProperties props) {
+        Map<String, Object> cfg = new HashMap<>(props.buildProducerProperties());
+        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        cfg.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(cfg);
+    }
+
+    // 알림 토픽 발행용 KafkaTemplate
+    @Bean
+    public KafkaTemplate<String, UsageAlertEvent> kafkaTemplate(
+            ProducerFactory<String, UsageAlertEvent> pf
+    ) {
+        return new KafkaTemplate<>(pf);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/config/RedisClientConfig.java
+++ b/src/main/java/hotspot/worker/consumer/config/RedisClientConfig.java
@@ -1,0 +1,21 @@
+package hotspot.worker.consumer.config;
+
+import java.time.ZoneId;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import hotspot.worker.consumer.support.RedisKeyBuilder;
+
+/**
+ * Consumer에서 사용하는 Redis 보조 설정
+ */
+@Configuration
+public class RedisClientConfig {
+
+    // Redis 키 규칙 빌더를 KST 기준으로 생성
+    @Bean
+    public RedisKeyBuilder redisKeyBuilder() {
+        return new RedisKeyBuilder(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/domain/GiftFire.java
+++ b/src/main/java/hotspot/worker/consumer/domain/GiftFire.java
@@ -1,0 +1,13 @@
+package hotspot.worker.consumer.domain;
+
+/**
+ * fired_gifts 항목 1건을 담는 DTO.
+ */
+public record GiftFire(
+        String giftId,
+        int th,
+        long rem,
+        int pct,
+        int last
+) {
+}

--- a/src/main/java/hotspot/worker/consumer/domain/GiftFire.java
+++ b/src/main/java/hotspot/worker/consumer/domain/GiftFire.java
@@ -1,7 +1,7 @@
 package hotspot.worker.consumer.domain;
 
 /**
- * fired_gifts 항목 1건을 담는 DTO.
+ * fired_gifts 항목 1건을 담는 DTO
  */
 public record GiftFire(
         String giftId,

--- a/src/main/java/hotspot/worker/consumer/domain/UsageLuaResult.java
+++ b/src/main/java/hotspot/worker/consumer/domain/UsageLuaResult.java
@@ -1,0 +1,25 @@
+package hotspot.worker.consumer.domain;
+
+import java.util.List;
+
+/**
+ * usage_atomic.lua 실행 결과 DTO
+ */
+public record UsageLuaResult(
+        boolean duplicate,
+        long bytes,
+        long giftTake,
+        long planTake,
+        long familyTake,
+        long overflow,
+        boolean planFired,
+        int planThreshold,
+        long planRemainingBytes,
+        int planRemainingPct,
+        boolean familyFired,
+        int familyThreshold,
+        long familyRemainingBytes,
+        int familyRemainingPct,
+        List<GiftFire> giftFires
+) {
+}

--- a/src/main/java/hotspot/worker/consumer/schema/UsageAlertEvent.java
+++ b/src/main/java/hotspot/worker/consumer/schema/UsageAlertEvent.java
@@ -1,0 +1,19 @@
+package hotspot.worker.consumer.schema;
+
+import java.time.Instant;
+
+/**
+ * usage-alert-events 발행 스키마
+ */
+public record UsageAlertEvent(
+        String alertType,
+        String threshold,
+        Instant occurredAt,
+        Long subId,
+        Long familyId,
+        String giftId,
+        long remainingBytes,
+        int remainingPct,
+        String sourceEventId
+) {
+}

--- a/src/main/java/hotspot/worker/consumer/schema/UsageEvent.java
+++ b/src/main/java/hotspot/worker/consumer/schema/UsageEvent.java
@@ -1,0 +1,16 @@
+package hotspot.worker.consumer.schema;
+
+import java.time.Instant;
+
+/**
+ * usage-events 수신 스키마
+ */
+public record UsageEvent(
+        String eventId,
+        long subId,
+        long familyId,
+        long bytes,
+        String appId,
+        Instant occurredAt
+) {
+}

--- a/src/main/java/hotspot/worker/consumer/service/AlertPublisher.java
+++ b/src/main/java/hotspot/worker/consumer/service/AlertPublisher.java
@@ -1,0 +1,30 @@
+package hotspot.worker.consumer.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import hotspot.worker.consumer.schema.UsageAlertEvent;
+
+/**
+ * 알림 이벤트를 Kafka로 발행하는 서비스
+ */
+@Service
+public class AlertPublisher {
+
+    private final KafkaTemplate<String, UsageAlertEvent> kafka;
+    private final String topic;
+
+    public AlertPublisher(
+            KafkaTemplate<String, UsageAlertEvent> kafka,
+            @Value("${app.topics.usage-alert-events}") String topic
+    ) {
+        this.kafka = kafka;
+        this.topic = topic;
+    }
+
+    // 발행 성공까지 대기하고 실패 시 예외를 발생
+    public void publish(String key, UsageAlertEvent event) {
+        kafka.send(topic, key, event).join();
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/service/UsageEventHandler.java
@@ -1,0 +1,97 @@
+package hotspot.worker.consumer.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import hotspot.worker.consumer.domain.GiftFire;
+import hotspot.worker.consumer.domain.UsageLuaResult;
+import hotspot.worker.consumer.schema.UsageAlertEvent;
+import hotspot.worker.consumer.schema.UsageEvent;
+
+/**
+ * 이벤트 1건 처리 유스케이스 서비스
+ */
+@Service
+public class UsageEventHandler {
+
+    private final UsageLuaExecutor lua;
+    private final AlertPublisher publisher;
+
+    public UsageEventHandler(UsageLuaExecutor lua, AlertPublisher publisher) {
+        this.lua = lua;
+        this.publisher = publisher;
+    }
+
+    // Lua 실행 결과를 바탕으로 필요한 알림만 발행
+    public void handle(UsageEvent ev) {
+        UsageLuaResult result = lua.execute(ev);
+        if (result.duplicate()) {
+            return;
+        }
+
+        List<UsageAlertEvent> alerts = new ArrayList<>();
+
+        if (result.planFired()) {
+            alerts.add(new UsageAlertEvent(
+                    "PLAN_REMAINING",
+                    String.valueOf(result.planThreshold()),
+                    ev.occurredAt(),
+                    ev.subId(),
+                    null,
+                    null,
+                    result.planRemainingBytes(),
+                    result.planRemainingPct(),
+                    ev.eventId()
+            ));
+        }
+
+        if (result.familyFired()) {
+            alerts.add(new UsageAlertEvent(
+                    "FAMILY_POOL_REMAINING",
+                    String.valueOf(result.familyThreshold()),
+                    ev.occurredAt(),
+                    null,
+                    ev.familyId(),
+                    null,
+                    result.familyRemainingBytes(),
+                    result.familyRemainingPct(),
+                    ev.eventId()
+            ));
+        }
+
+        for (GiftFire giftFire : result.giftFires()) {
+            alerts.add(new UsageAlertEvent(
+                    "GIFT_REMAINING",
+                    String.valueOf(giftFire.th()),
+                    ev.occurredAt(),
+                    ev.subId(),
+                    null,
+                    giftFire.giftId(),
+                    giftFire.rem(),
+                    giftFire.pct(),
+                    ev.eventId()
+            ));
+        }
+
+        for (UsageAlertEvent alert : alerts) {
+            String key = keyFor(alert);
+            publisher.publish(key, alert);
+        }
+    }
+
+    // 알림 대상에 따라 Kafka partition key를 만듦
+    private String keyFor(UsageAlertEvent event) {
+        if (event.subId() != null) {
+            return "sub:" + event.subId();
+        }
+        if (event.familyId() != null) {
+            return "family:" + event.familyId();
+        }
+        if (event.giftId() != null) {
+            return "gift:" + event.giftId();
+        }
+        return "unknown";
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/service/UsageEventHandler.java
@@ -81,16 +81,16 @@ public class UsageEventHandler {
         }
     }
 
-    // 알림 대상에 따라 Kafka partition key를 만듦
+    // 알림 타입에 따라 Kafka partition key를 생성
     private String keyFor(UsageAlertEvent event) {
+        if ("GIFT_REMAINING".equals(event.alertType()) && event.giftId() != null) {
+            return "gift:" + event.giftId();
+        }
         if (event.subId() != null) {
             return "sub:" + event.subId();
         }
         if (event.familyId() != null) {
             return "family:" + event.familyId();
-        }
-        if (event.giftId() != null) {
-            return "gift:" + event.giftId();
         }
         return "unknown";
     }

--- a/src/main/java/hotspot/worker/consumer/service/UsageEventsConsumer.java
+++ b/src/main/java/hotspot/worker/consumer/service/UsageEventsConsumer.java
@@ -1,0 +1,30 @@
+package hotspot.worker.consumer.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import hotspot.worker.consumer.schema.UsageEvent;
+
+/**
+ * usage-events 수신 진입점
+ */
+@Component
+public class UsageEventsConsumer {
+
+    private final UsageEventHandler handler;
+
+    public UsageEventsConsumer(UsageEventHandler handler) {
+        this.handler = handler;
+    }
+
+    // 처리 성공 시에만 수동 ACK를 수행
+    @KafkaListener(
+            topics = "${app.topics.usage-events}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(UsageEvent ev, Acknowledgment ack) {
+        handler.handle(ev);
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/service/UsageLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/service/UsageLuaExecutor.java
@@ -1,0 +1,144 @@
+package hotspot.worker.consumer.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.worker.consumer.domain.GiftFire;
+import hotspot.worker.consumer.domain.UsageLuaResult;
+import hotspot.worker.consumer.schema.UsageEvent;
+import hotspot.worker.consumer.support.RedisKeyBuilder;
+
+/**
+ * usage_atomic.lua 실행과 결과 파싱을 담당하는 서비스
+ */
+@Service
+public class UsageLuaExecutor {
+
+    private static final long TTL_MON_SECONDS = 2_678_400L;
+    private static final long TTL_DAY_SECONDS = 172_800L;
+    private static final long TTL_NOTIFY_SECONDS = 2_678_400L;
+    private static final long TTL_DEDUP_SECONDS = 86_400L;
+
+    private final StringRedisTemplate redis;
+    private final DefaultRedisScript<List> usageAtomicScript;
+    private final RedisKeyBuilder keyBuilder;
+    private final ObjectMapper om;
+
+    public UsageLuaExecutor(
+            StringRedisTemplate redis,
+            DefaultRedisScript<List> usageAtomicScript,
+            RedisKeyBuilder keyBuilder,
+            ObjectMapper om
+    ) {
+        this.redis = redis;
+        this.usageAtomicScript = usageAtomicScript;
+        this.keyBuilder = keyBuilder;
+        this.om = om;
+    }
+
+    // 이벤트 1건을 Lua로 원자 처리하고 결과 DTO로 변환
+    public UsageLuaResult execute(UsageEvent ev) {
+        RedisKeyBuilder.Keys keysPack =
+                keyBuilder.build(ev.subId(), ev.familyId(), ev.eventId(), ev.occurredAt());
+
+        List<String> argv = List.of(
+                String.valueOf(ev.bytes()),
+                ev.appId(),
+                keysPack.yyyymm(),
+                keysPack.giftLimitPrefix(),
+                keysPack.giftUsagePrefix(),
+                keysPack.giftNotifyPrefix(),
+                String.valueOf(TTL_MON_SECONDS),
+                String.valueOf(TTL_DAY_SECONDS),
+                String.valueOf(TTL_NOTIFY_SECONDS),
+                String.valueOf(TTL_DEDUP_SECONDS)
+        );
+
+        Object[] argvArray = argv.toArray(new Object[0]);
+        Object raw = redis.execute(usageAtomicScript, keysPack.keys(), argvArray);
+        @SuppressWarnings("unchecked")
+        List<Object> arr = (List<Object>) raw;
+
+        if (arr.size() == 1 && "DUP".equals(toStr(arr.get(0)))) {
+            return new UsageLuaResult(
+                    true,
+                    0, 0, 0, 0, 0,
+                    false, 101, 0, 0,
+                    false, 101, 0, 0,
+                    List.of()
+            );
+        }
+
+        String status = toStr(arr.get(0));
+        if (!"OK".equals(status)) {
+            throw new IllegalStateException("Lua returned unexpected status: " + status);
+        }
+
+        long bytes = toLong(arr.get(1));
+        long giftTake = toLong(arr.get(2));
+        long planTake = toLong(arr.get(3));
+        long familyTake = toLong(arr.get(4));
+        long overflow = toLong(arr.get(5));
+
+        boolean planFire = toLong(arr.get(10)) == 1;
+        int planTh = (int) toLong(arr.get(11));
+        long planRem = toLong(arr.get(12));
+        int planPct = (int) toLong(arr.get(13));
+
+        boolean famFire = toLong(arr.get(15)) == 1;
+        int famTh = (int) toLong(arr.get(16));
+        long famRem = toLong(arr.get(17));
+        int famPct = (int) toLong(arr.get(18));
+
+        String firedJson = toStr(arr.get(20));
+        List<GiftFire> giftFires = parseGiftFires(firedJson);
+
+        return new UsageLuaResult(
+                false,
+                bytes, giftTake, planTake, familyTake, overflow,
+                planFire, planTh, planRem, planPct,
+                famFire, famTh, famRem, famPct,
+                giftFires
+        );
+    }
+
+    // fired_gifts JSON을 GiftFire 리스트로 변환
+    private List<GiftFire> parseGiftFires(String json) {
+        if (json == null || json.isBlank() || "[]".equals(json)) {
+            return List.of();
+        }
+        try {
+            return om.readValue(json, new TypeReference<List<GiftFire>>() {
+            });
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse fired_gifts JSON: " + json, e);
+        }
+    }
+
+    // Redis 반환값을 문자열로 변환
+    private String toStr(Object o) {
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return o.toString();
+    }
+
+    // Redis 반환값을 숫자로 변환
+    private long toLong(Object o) {
+        String s = toStr(o);
+        if (s == null || s.isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(s);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/service/UsageLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/service/UsageLuaExecutor.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.worker.consumer.domain.GiftFire;
@@ -111,12 +112,24 @@ public class UsageLuaExecutor {
 
     // fired_gifts JSON을 GiftFire 리스트로 변환
     private List<GiftFire> parseGiftFires(String json) {
-        if (json == null || json.isBlank() || "[]".equals(json)) {
+        if (json == null || json.isBlank()) {
             return List.of();
         }
         try {
-            return om.readValue(json, new TypeReference<List<GiftFire>>() {
-            });
+            JsonNode node = om.readTree(json);
+            if (node == null || node.isNull() || node.isMissingNode()) {
+                return List.of();
+            }
+            if (node.isObject() && node.isEmpty()) {
+                return List.of();
+            }
+            if (node.isArray()) {
+                return om.convertValue(node, new TypeReference<List<GiftFire>>() {
+                });
+            }
+            throw new IllegalStateException("Unexpected fired_gifts JSON shape: " + json);
+        } catch (IllegalStateException e) {
+            throw e;
         } catch (Exception e) {
             throw new IllegalStateException("Failed to parse fired_gifts JSON: " + json, e);
         }

--- a/src/main/java/hotspot/worker/consumer/support/RedisKeyBuilder.java
+++ b/src/main/java/hotspot/worker/consumer/support/RedisKeyBuilder.java
@@ -1,0 +1,73 @@
+package hotspot.worker.consumer.support;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * usage Lua 실행용 Redis 키를 규약대로 생성하는 빌더
+ */
+public final class RedisKeyBuilder {
+
+    private final ZoneId zone;
+
+    public RedisKeyBuilder(ZoneId zone) {
+        this.zone = zone;
+    }
+
+    // Lua KEYS와 접두사 파라미터 묶음
+    public record Keys(
+            List<String> keys,
+            String yyyymm,
+            String giftLimitPrefix,
+            String giftUsagePrefix,
+            String giftNotifyPrefix
+    ) {
+    }
+
+    // 이벤트 기준으로 Lua KEYS/ARGV 구성값을 만듦
+    public Keys build(long subId, long familyId, String eventId, Instant occurredAt) {
+        String yyyymm = TimeKey.yyyymm(occurredAt, zone);
+        String yyyymmdd = TimeKey.yyyymmdd(occurredAt, zone);
+
+        String limitSubKey = "limit:sub:" + subId;
+        String limitFamilyKey = "limit:family:" + familyId;
+        String limitFamilySubKey = "limit:family_sub:" + familyId + ":" + subId;
+        String giftIdxKey = "idx:gift:" + subId + ":" + yyyymm;
+
+        String usageSubMonKey = "usage:sub:" + subId + ":" + yyyymm;
+        String usageSubDayKey = "usage:sub:" + subId + ":" + yyyymmdd;
+        String usageFamilyMonKey = "usage:family:" + familyId + ":" + yyyymm;
+        String usageFamilyDayKey = "usage:family:" + familyId + ":" + yyyymmdd;
+        String usageAppMonKey = "usage:app:" + subId + ":" + yyyymm;
+        String usageAppDayKey = "usage:app:" + subId + ":" + yyyymmdd;
+
+        String notifyPlanMonKey = "notify:sub:" + subId + ":" + yyyymm;
+        String notifyPlanDayKey = "notify:sub:" + subId + ":" + yyyymmdd;
+        String notifyFamilyMonKey = "notify:family:" + familyId + ":" + yyyymm;
+        String dedupKey = "dedup:evt:" + eventId;
+
+        List<String> keys = List.of(
+                limitSubKey,
+                limitFamilyKey,
+                limitFamilySubKey,
+                giftIdxKey,
+                usageSubMonKey,
+                usageSubDayKey,
+                usageFamilyMonKey,
+                usageFamilyDayKey,
+                usageAppMonKey,
+                usageAppDayKey,
+                notifyPlanMonKey,
+                notifyPlanDayKey,
+                notifyFamilyMonKey,
+                dedupKey
+        );
+
+        String giftLimitPrefix = "limit:gift:" + subId + ":";
+        String giftUsagePrefix = "usage:gift:" + subId + ":";
+        String giftNotifyPrefix = "notify:gift:" + subId + ":";
+
+        return new Keys(keys, yyyymm, giftLimitPrefix, giftUsagePrefix, giftNotifyPrefix);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/support/TimeKey.java
+++ b/src/main/java/hotspot/worker/consumer/support/TimeKey.java
@@ -1,0 +1,27 @@
+package hotspot.worker.consumer.support;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * 이벤트 시각을 Redis 키 날짜 포맷으로 변환하는 유틸
+ */
+public final class TimeKey {
+
+    // 유틸 클래스 인스턴스화 방지
+    private TimeKey() {
+    }
+
+    // YYYYMM 문자열을 반환
+    public static String yyyymm(Instant ts, ZoneId zone) {
+        ZonedDateTime z = ts.atZone(zone);
+        return String.format("%04d%02d", z.getYear(), z.getMonthValue());
+    }
+
+    // YYYYMMDD 문자열을 반환
+    public static String yyyymmdd(Instant ts, ZoneId zone) {
+        ZonedDateTime z = ts.atZone(zone);
+        return String.format("%04d%02d%02d", z.getYear(), z.getMonthValue(), z.getDayOfMonth());
+    }
+}

--- a/src/main/resources/kafka.yml
+++ b/src/main/resources/kafka.yml
@@ -14,6 +14,7 @@ spring:
       batch-size: 16384
 
     consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:usage-consumer-group}
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       auto-offset-reset: earliest
@@ -21,3 +22,8 @@ spring:
 
     listener:
       ack-mode: manual
+
+app:
+  topics:
+    usage-events: ${KAFKA_TOPIC_USAGE_EVENTS:usage-events}
+    usage-alert-events: ${KAFKA_TOPIC_USAGE_ALERT_EVENTS:usage-alert-events}

--- a/src/main/resources/lua/usage_atomic.lua
+++ b/src/main/resources/lua/usage_atomic.lua
@@ -1,26 +1,30 @@
--- KEYS
---  1: limit:sub:{subId}
---  2: limit:family:{familyId}
---  3: limit:family_sub:{familyId}:{subId}
---  4: idx:gift:{subId}:{yyyymm}
---  5: usage:sub:{subId}:{yyyymm}
---  6: usage:sub:{subId}:{yyyymmdd}
---  7: usage:family:{familyId}:{yyyymm}
---  8: usage:family:{familyId}:{yyyymmdd}
---  9: usage:app:{subId}:{yyyymm}
--- 10: usage:app:{subId}:{yyyymmdd}
--- 11: notify:sub:{subId}:{yyyymm}
--- 12: notify:sub:{subId}:{yyyymmdd}
--- 13: notify:family:{familyId}:{yyyymm}
--- 14: dedup:evt:{eventId}
+-- -------------------------
+-- KEYS (고정 인자)
+-- -------------------------
+--  1: limit:sub:{subId}                    (HASH) plan_limit
+--  2: limit:family:{familyId}              (HASH) family_limit
+--  3: limit:family_sub:{familyId}:{subId}  (HASH) family_member_limit
+--  4: idx:gift:{subId}:{yyyymm}            (ZSET) giftId 목록
+--  5: usage:sub:{subId}:{yyyymm}           (HASH) 월 사용량
+--  6: usage:sub:{subId}:{yyyymmdd}         (HASH) 일 사용량
+--  7: usage:family:{familyId}:{yyyymm}     (HASH) 가족 풀 월 사용량
+--  8: usage:family:{familyId}:{yyyymmdd}   (HASH) 가족 풀 일 사용량
+--  9: usage:app:{subId}:{yyyymm}           (ZSET) 월 앱별 사용량
+-- 10: usage:app:{subId}:{yyyymmdd}         (ZSET) 일 앱별 사용량
+-- 11: notify:sub:{subId}:{yyyymm}          (STRING) 요금제 월 임계치 상태
+-- 12: notify:sub:{subId}:{yyyymmdd}        (STRING) 요금제 일 임계치 상태
+-- 13: notify:family:{familyId}:{yyyymm}    (STRING) 가족 풀 월 임계치 상태
+-- 14: dedup:evt:{eventId}                  (STRING) 중복 방지 키
 
--- ARGV
---  1: bytes
+-- -------------------------
+-- ARGV (가변 인자)
+-- -------------------------
+--  1: bytes (이번 이벤트 사용량)
 --  2: appId
 --  3: yyyymm
---  4: giftLimitPrefix
---  5: giftUsagePrefix
---  6: giftNotifyPrefix
+--  4: giftLimitPrefix   ("limit:gift:")
+--  5: giftUsagePrefix   ("usage:gift:")
+--  6: giftNotifyPrefix  ("notify:gift:")
 --  7: ttlMon
 --  8: ttlDay
 --  9: ttlNotify
@@ -29,26 +33,41 @@
 local bytes = tonumber(ARGV[1])
 local appId = ARGV[2]
 local yyyymm = ARGV[3]
+
+-- gift 관련 실제 키는 prefix + gid + ":" + yyyymm 로 조립
 local giftLimitPrefix = ARGV[4]
 local giftUsagePrefix = ARGV[5]
 local giftNotifyPrefix = ARGV[6]
+
+-- TTL (seconds)
 local ttlMon = tonumber(ARGV[7])
 local ttlDay = tonumber(ARGV[8])
 local ttlNotify = tonumber(ARGV[9])
 local ttlDedup = tonumber(ARGV[10])
 
+-- =========================================================
+-- 1) Dedup: eventId가 이미 처리되었으면 DUP 반환
+-- =========================================================
 local ok = redis.call('SET', KEYS[14], '1', 'NX', 'EX', ttlDedup)
 if not ok then
   return { "DUP" }
 end
 
+-- =========================================================
+-- 2) Helper: threshold(quota, used)
+--    - quota 기준으로 잔여% 구간을 50/30/10/0으로 환산
+--    - 101은 알림 대상 아님 의미(초기/정상 구간)
+-- =========================================================
 local function threshold(quota, used)
   if quota == nil or quota <= 0 then
     return 101, 0, 0
   end
+
   local rem = quota - used
   if rem < 0 then rem = 0 end
+
   local pct = math.floor(rem * 100 / quota)
+
   if rem == 0 then return 0, rem, pct end
   if pct <= 10 then return 10, rem, pct end
   if pct <= 30 then return 30, rem, pct end
@@ -56,23 +75,35 @@ local function threshold(quota, used)
   return 101, rem, pct
 end
 
+-- =========================================================
+-- 3) Helper: update_notify(key, new_th)
+--    - 마지막 임계치(last)보다 더 낮아질 때만 fire=1
+--    - new_th==101이면 상태값 변경은 안 하고 TTL만 연장
+-- =========================================================
 local function update_notify(key, new_th)
   if new_th == 101 then
+    -- 정상 구간: 값은 굳이 쓰지 않고 TTL만 유지
     redis.call('EXPIRE', key, ttlNotify)
     return 0, 101
   end
 
   local last = tonumber(redis.call('GET', key) or '101')
+
   if new_th < last then
+    -- 임계치가 하락할 때만 알림 발화 대상
     redis.call('SET', key, tostring(new_th))
     redis.call('EXPIRE', key, ttlNotify)
     return 1, last
   end
 
+  -- 이미 더 낮은(또는 같은) 구간에 있으므로 fire 없음, TTL만 갱신
   redis.call('EXPIRE', key, ttlNotify)
   return 0, last
 end
 
+-- =========================================================
+-- 4) Limit/Usage 로드 (이번 이벤트 처리 전 기준)
+-- =========================================================
 local plan_limit = tonumber(redis.call('HGET', KEYS[1], 'plan_limit') or '0')
 local family_limit_total = tonumber(redis.call('HGET', KEYS[2], 'family_limit') or '0')
 local family_member_limit = tonumber(redis.call('HGET', KEYS[3], 'family_limit') or '0')
@@ -81,35 +112,51 @@ local mon_plan_used = tonumber(redis.call('HGET', KEYS[5], 'plan_used') or '0')
 local mon_family_used = tonumber(redis.call('HGET', KEYS[5], 'member_family_used') or '0')
 local mon_pool_used = tonumber(redis.call('HGET', KEYS[7], 'family_used') or '0')
 
+-- 잔여량 계산
 local plan_rem = plan_limit - mon_plan_used
 if plan_rem < 0 then plan_rem = 0 end
 
 local pool_rem = family_limit_total - mon_pool_used
 if pool_rem < 0 then pool_rem = 0 end
 
+-- 가족에서 이 멤버가 더 쓸 수 있는 잔여량
+-- (개인한도 0이면 무제한 취급 -> 일단 pool_rem을 기준으로 두고,
+--  최종 cap에서 min(pool_rem, member_rem) 적용)
 local member_rem = pool_rem
 if family_member_limit > 0 then
   member_rem = family_member_limit - mon_family_used
   if member_rem < 0 then member_rem = 0 end
 end
 
-local remain = bytes
-local gift_take_total = 0
-local fired_gifts = {}
+-- =========================================================
+-- 5) bytes를 어디서 충당할지 계산: Gift -> Plan -> Family -> Overflow
+-- =========================================================
+local remain = bytes              -- 아직 충당 못한 사용량
+local gift_take_total = 0         -- 이번 이벤트에서 gift로 충당한 총량
+local fired_gifts = {}            -- gift별 알림 fire 결과 모음
 
+-- -------------------------
+-- 5-1) Gift 차감 (idx:gift ZSET 순서대로)
+-- -------------------------
 local gift_ids = redis.call('ZRANGE', KEYS[4], 0, -1)
+
 for i = 1, #gift_ids do
-  if remain <= 0 then break end
+  if remain <= 0 then break end   -- 이미 전량 충당했으면 종료
 
   local gid = gift_ids[i]
+
+  -- gift limit/usage 키 조립: prefix + gid + ":" + yyyymm
   local gift_limit_key = giftLimitPrefix .. gid .. ":" .. yyyymm
   local gift_usage_key = giftUsagePrefix .. gid .. ":" .. yyyymm
+
   local gift_quota = tonumber(redis.call('HGET', gift_limit_key, 'gift_limit') or '0')
   local gift_used = tonumber(redis.call('HGET', gift_usage_key, 'gift_used') or '0')
+
   local gift_rem = gift_quota - gift_used
   if gift_rem < 0 then gift_rem = 0 end
 
   if gift_rem > 0 then
+    -- 이번 이벤트 remain 중 gift가 커버 가능한 만큼 take
     local take = remain
     if take > gift_rem then take = gift_rem end
 
@@ -117,76 +164,127 @@ for i = 1, #gift_ids do
     gift_take_total = gift_take_total + take
     gift_used = gift_used + take
 
+    -- gift 사용량 누적 + TTL 유지
     redis.call('HINCRBY', gift_usage_key, 'gift_used', take)
     redis.call('EXPIRE', gift_usage_key, ttlMon)
     redis.call('EXPIRE', gift_limit_key, ttlMon)
 
+    -- gift를 다 썼으면 인덱스에서 제거해서 다음부터 스캔 비용 감소
     if gift_quota > 0 and gift_used >= gift_quota then
       redis.call('ZREM', KEYS[4], gid)
     end
 
+    -- gift 임계치 알림 판정
     local th, rem2, pct = threshold(gift_quota, gift_used)
     local nkey = giftNotifyPrefix .. gid .. ":" .. yyyymm
     local fire, last = update_notify(nkey, th)
+
     if fire == 1 then
-      table.insert(fired_gifts, { giftId = gid, th = th, rem = rem2, pct = pct, last = last })
+      table.insert(fired_gifts, {
+        giftId = gid, th = th, rem = rem2, pct = pct, last = last
+      })
     end
   end
 end
 
+-- -------------------------
+-- 5-2) Plan 차감 (개인 요금제 잔여까지)
+-- -------------------------
 local plan_take = remain
 if plan_take > plan_rem then plan_take = plan_rem end
 remain = remain - plan_take
 
+-- -------------------------
+-- 5-3) Family 차감 (pool 잔여 + 개인 한도 잔여 동시 반영)
+-- -------------------------
 local fam_cap = pool_rem
 if member_rem < fam_cap then fam_cap = member_rem end
+
 local family_take = remain
 if family_take > fam_cap then family_take = fam_cap end
 remain = remain - family_take
 
+-- -------------------------
+-- 5-4) Overflow (어디에도 못 담긴 초과분)
+-- -------------------------
 local overflow = remain
 
+-- =========================================================
+-- 6) 집계 키 업데이트 (월/일/가족/앱별)
+-- =========================================================
+
+-- (A) sub 월 usage hash
 redis.call('HINCRBY', KEYS[5], 'total_used', bytes)
 redis.call('HINCRBY', KEYS[5], 'plan_used', plan_take)
 redis.call('HINCRBY', KEYS[5], 'member_family_used', family_take)
 redis.call('HINCRBY', KEYS[5], 'gift_used', gift_take_total)
-if overflow > 0 then redis.call('HINCRBY', KEYS[5], 'overflow_used', overflow) end
+if overflow > 0 then
+  redis.call('HINCRBY', KEYS[5], 'overflow_used', overflow)
+end
 redis.call('EXPIRE', KEYS[5], ttlMon)
 
+-- (B) sub 일 usage hash
 redis.call('HINCRBY', KEYS[6], 'total_used', bytes)
 redis.call('HINCRBY', KEYS[6], 'plan_used', plan_take)
 redis.call('HINCRBY', KEYS[6], 'member_family_used', family_take)
 redis.call('HINCRBY', KEYS[6], 'gift_used', gift_take_total)
-if overflow > 0 then redis.call('HINCRBY', KEYS[6], 'overflow_used', overflow) end
+if overflow > 0 then
+  redis.call('HINCRBY', KEYS[6], 'overflow_used', overflow)
+end
 redis.call('EXPIRE', KEYS[6], ttlDay)
 
+-- (C) family 월/일 usage hash (가족 풀에서 실제로 빠진 양만 기록)
 redis.call('HINCRBY', KEYS[7], 'family_used', family_take)
 redis.call('HINCRBY', KEYS[8], 'family_used', family_take)
 redis.call('EXPIRE', KEYS[7], ttlMon)
 redis.call('EXPIRE', KEYS[8], ttlDay)
 
+-- (D) app별 ZSET (월/일)
 redis.call('ZINCRBY', KEYS[9], bytes, appId)
 redis.call('ZINCRBY', KEYS[10], bytes, appId)
 redis.call('EXPIRE', KEYS[9], ttlMon)
 redis.call('EXPIRE', KEYS[10], ttlDay)
+
+-- gift index도 월 TTL 유지
 redis.call('EXPIRE', KEYS[4], ttlMon)
 
+-- =========================================================
+-- 7) Notify 업데이트 (Plan: 월/일, Family: 월)
+-- =========================================================
+
+-- Plan notify
 local plan_used_new = mon_plan_used + plan_take
 local plan_th, plan_rem2, plan_pct = threshold(plan_limit, plan_used_new)
-local plan_fire, plan_last = update_notify(KEYS[11], plan_th)
-update_notify(KEYS[12], plan_th)
 
+local plan_fire, plan_last = update_notify(KEYS[11], plan_th)  -- 월 fire 여부
+update_notify(KEYS[12], plan_th)                               -- 일은 상태만 유지
+
+-- Family pool notify (월)
 local pool_used_new = mon_pool_used + family_take
 local fam_th, fam_rem2, fam_pct = threshold(family_limit_total, pool_used_new)
+
 local fam_fire, fam_last = update_notify(KEYS[13], fam_th)
 
+-- =========================================================
+-- 8) 결과 반환 (컨슈머/프로듀서가 다음 로직에서 사용)
+-- =========================================================
 return {
   "OK",
   bytes,
   gift_take_total, plan_take, family_take, overflow,
+
+  -- 가족 풀 사용량/잔여
   pool_used_new, (family_limit_total - pool_used_new),
+
+  -- 멤버 개인 가족사용량/개인한도
   (mon_family_used + family_take), family_member_limit,
+
+  -- plan notify: fire 여부, 현재 임계치, 잔여량/잔여%, 이전 임계치
   plan_fire, plan_th, plan_rem2, plan_pct, plan_last,
+
+  -- family notify: fire 여부, 현재 임계치, 잔여량/잔여%, 이전 임계치
   fam_fire, fam_th, fam_rem2, fam_pct, fam_last,
+
+  -- gift notify fire 목록(JSON)
   cjson.encode(fired_gifts)
 }

--- a/src/main/resources/lua/usage_atomic.lua
+++ b/src/main/resources/lua/usage_atomic.lua
@@ -1,0 +1,192 @@
+-- KEYS
+--  1: limit:sub:{subId}
+--  2: limit:family:{familyId}
+--  3: limit:family_sub:{familyId}:{subId}
+--  4: idx:gift:{subId}:{yyyymm}
+--  5: usage:sub:{subId}:{yyyymm}
+--  6: usage:sub:{subId}:{yyyymmdd}
+--  7: usage:family:{familyId}:{yyyymm}
+--  8: usage:family:{familyId}:{yyyymmdd}
+--  9: usage:app:{subId}:{yyyymm}
+-- 10: usage:app:{subId}:{yyyymmdd}
+-- 11: notify:sub:{subId}:{yyyymm}
+-- 12: notify:sub:{subId}:{yyyymmdd}
+-- 13: notify:family:{familyId}:{yyyymm}
+-- 14: dedup:evt:{eventId}
+
+-- ARGV
+--  1: bytes
+--  2: appId
+--  3: yyyymm
+--  4: giftLimitPrefix
+--  5: giftUsagePrefix
+--  6: giftNotifyPrefix
+--  7: ttlMon
+--  8: ttlDay
+--  9: ttlNotify
+-- 10: ttlDedup
+
+local bytes = tonumber(ARGV[1])
+local appId = ARGV[2]
+local yyyymm = ARGV[3]
+local giftLimitPrefix = ARGV[4]
+local giftUsagePrefix = ARGV[5]
+local giftNotifyPrefix = ARGV[6]
+local ttlMon = tonumber(ARGV[7])
+local ttlDay = tonumber(ARGV[8])
+local ttlNotify = tonumber(ARGV[9])
+local ttlDedup = tonumber(ARGV[10])
+
+local ok = redis.call('SET', KEYS[14], '1', 'NX', 'EX', ttlDedup)
+if not ok then
+  return { "DUP" }
+end
+
+local function threshold(quota, used)
+  if quota == nil or quota <= 0 then
+    return 101, 0, 0
+  end
+  local rem = quota - used
+  if rem < 0 then rem = 0 end
+  local pct = math.floor(rem * 100 / quota)
+  if rem == 0 then return 0, rem, pct end
+  if pct <= 10 then return 10, rem, pct end
+  if pct <= 30 then return 30, rem, pct end
+  if pct <= 50 then return 50, rem, pct end
+  return 101, rem, pct
+end
+
+local function update_notify(key, new_th)
+  if new_th == 101 then
+    redis.call('EXPIRE', key, ttlNotify)
+    return 0, 101
+  end
+
+  local last = tonumber(redis.call('GET', key) or '101')
+  if new_th < last then
+    redis.call('SET', key, tostring(new_th))
+    redis.call('EXPIRE', key, ttlNotify)
+    return 1, last
+  end
+
+  redis.call('EXPIRE', key, ttlNotify)
+  return 0, last
+end
+
+local plan_limit = tonumber(redis.call('HGET', KEYS[1], 'plan_limit') or '0')
+local family_limit_total = tonumber(redis.call('HGET', KEYS[2], 'family_limit') or '0')
+local family_member_limit = tonumber(redis.call('HGET', KEYS[3], 'family_limit') or '0')
+
+local mon_plan_used = tonumber(redis.call('HGET', KEYS[5], 'plan_used') or '0')
+local mon_family_used = tonumber(redis.call('HGET', KEYS[5], 'member_family_used') or '0')
+local mon_pool_used = tonumber(redis.call('HGET', KEYS[7], 'family_used') or '0')
+
+local plan_rem = plan_limit - mon_plan_used
+if plan_rem < 0 then plan_rem = 0 end
+
+local pool_rem = family_limit_total - mon_pool_used
+if pool_rem < 0 then pool_rem = 0 end
+
+local member_rem = pool_rem
+if family_member_limit > 0 then
+  member_rem = family_member_limit - mon_family_used
+  if member_rem < 0 then member_rem = 0 end
+end
+
+local remain = bytes
+local gift_take_total = 0
+local fired_gifts = {}
+
+local gift_ids = redis.call('ZRANGE', KEYS[4], 0, -1)
+for i = 1, #gift_ids do
+  if remain <= 0 then break end
+
+  local gid = gift_ids[i]
+  local gift_limit_key = giftLimitPrefix .. gid .. ":" .. yyyymm
+  local gift_usage_key = giftUsagePrefix .. gid .. ":" .. yyyymm
+  local gift_quota = tonumber(redis.call('HGET', gift_limit_key, 'gift_limit') or '0')
+  local gift_used = tonumber(redis.call('HGET', gift_usage_key, 'gift_used') or '0')
+  local gift_rem = gift_quota - gift_used
+  if gift_rem < 0 then gift_rem = 0 end
+
+  if gift_rem > 0 then
+    local take = remain
+    if take > gift_rem then take = gift_rem end
+
+    remain = remain - take
+    gift_take_total = gift_take_total + take
+    gift_used = gift_used + take
+
+    redis.call('HINCRBY', gift_usage_key, 'gift_used', take)
+    redis.call('EXPIRE', gift_usage_key, ttlMon)
+    redis.call('EXPIRE', gift_limit_key, ttlMon)
+
+    if gift_quota > 0 and gift_used >= gift_quota then
+      redis.call('ZREM', KEYS[4], gid)
+    end
+
+    local th, rem2, pct = threshold(gift_quota, gift_used)
+    local nkey = giftNotifyPrefix .. gid .. ":" .. yyyymm
+    local fire, last = update_notify(nkey, th)
+    if fire == 1 then
+      table.insert(fired_gifts, { giftId = gid, th = th, rem = rem2, pct = pct, last = last })
+    end
+  end
+end
+
+local plan_take = remain
+if plan_take > plan_rem then plan_take = plan_rem end
+remain = remain - plan_take
+
+local fam_cap = pool_rem
+if member_rem < fam_cap then fam_cap = member_rem end
+local family_take = remain
+if family_take > fam_cap then family_take = fam_cap end
+remain = remain - family_take
+
+local overflow = remain
+
+redis.call('HINCRBY', KEYS[5], 'total_used', bytes)
+redis.call('HINCRBY', KEYS[5], 'plan_used', plan_take)
+redis.call('HINCRBY', KEYS[5], 'member_family_used', family_take)
+redis.call('HINCRBY', KEYS[5], 'gift_used', gift_take_total)
+if overflow > 0 then redis.call('HINCRBY', KEYS[5], 'overflow_used', overflow) end
+redis.call('EXPIRE', KEYS[5], ttlMon)
+
+redis.call('HINCRBY', KEYS[6], 'total_used', bytes)
+redis.call('HINCRBY', KEYS[6], 'plan_used', plan_take)
+redis.call('HINCRBY', KEYS[6], 'member_family_used', family_take)
+redis.call('HINCRBY', KEYS[6], 'gift_used', gift_take_total)
+if overflow > 0 then redis.call('HINCRBY', KEYS[6], 'overflow_used', overflow) end
+redis.call('EXPIRE', KEYS[6], ttlDay)
+
+redis.call('HINCRBY', KEYS[7], 'family_used', family_take)
+redis.call('HINCRBY', KEYS[8], 'family_used', family_take)
+redis.call('EXPIRE', KEYS[7], ttlMon)
+redis.call('EXPIRE', KEYS[8], ttlDay)
+
+redis.call('ZINCRBY', KEYS[9], bytes, appId)
+redis.call('ZINCRBY', KEYS[10], bytes, appId)
+redis.call('EXPIRE', KEYS[9], ttlMon)
+redis.call('EXPIRE', KEYS[10], ttlDay)
+redis.call('EXPIRE', KEYS[4], ttlMon)
+
+local plan_used_new = mon_plan_used + plan_take
+local plan_th, plan_rem2, plan_pct = threshold(plan_limit, plan_used_new)
+local plan_fire, plan_last = update_notify(KEYS[11], plan_th)
+update_notify(KEYS[12], plan_th)
+
+local pool_used_new = mon_pool_used + family_take
+local fam_th, fam_rem2, fam_pct = threshold(family_limit_total, pool_used_new)
+local fam_fire, fam_last = update_notify(KEYS[13], fam_th)
+
+return {
+  "OK",
+  bytes,
+  gift_take_total, plan_take, family_take, overflow,
+  pool_used_new, (family_limit_total - pool_used_new),
+  (mon_family_used + family_take), family_member_limit,
+  plan_fire, plan_th, plan_rem2, plan_pct, plan_last,
+  fam_fire, fam_th, fam_rem2, fam_pct, fam_last,
+  cjson.encode(fired_gifts)
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-65

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #12 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- Consumer 구독 설정 추가
- Redis 보조 설정 추가
- 중복 방지(idempotency) 처리
- Redis 집계 로직 Lua 구현 및 등록 (개인/가족/선물 사용량 반영)
- Redis 잔여량/누적 상태 갱신 및 소진 플래그 처리
- 통합 테스트 (샘플 이벤트 → Redis 값 검증)


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
- SeedRunner의 위치가 /src/main/java/hotspot/seed 패키지 안으로 변경되었습니다.