### PR TITLE
[HOTSPOT-112] RDB와 Redis 정합성 Consumer 로직 구현

### DIFF
--- a/src/main/java/hotspot/worker/common/config/redis/RedisLuaConfig.java
+++ b/src/main/java/hotspot/worker/common/config/redis/RedisLuaConfig.java
@@ -13,7 +13,8 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 @Configuration
 public class RedisLuaConfig {
 
-    // 정책 검증 Lua Script
+    /* ================= 데이터 사용량 스크립트 ================= */
+
     @Bean
     public DefaultRedisScript<List> usageValidBatchScript() {
         DefaultRedisScript<List> script = new DefaultRedisScript<>();
@@ -22,12 +23,79 @@ public class RedisLuaConfig {
         return script;
     }
 
-    // 사용량 집계 Lua Script
     @Bean
     public DefaultRedisScript<List> usageAtomicScript() {
         DefaultRedisScript<List> script = new DefaultRedisScript<>();
         script.setLocation(new ClassPathResource("lua/usage_atomic.lua"));
         script.setResultType(List.class);
+        return script;
+    }
+
+    /* ================= Family 정합성 스크립트 ================= */
+
+    @Bean
+    public DefaultRedisScript<Long> familyMemberScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/family_member.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> familyModeScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/family_mode.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> familySubLimitScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/family_sub_limit.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    /* ================= Subscription 정합성 스크립트 ================= */
+
+    @Bean
+    public DefaultRedisScript<Long> subscriptionLockScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/subscription_lock.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> subscriptionPlanChangedScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/subscription_plan_changed.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> subscriptionPolicyScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/subscription_policy.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> subscriptionGiftScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/subscription_gift.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
+    public DefaultRedisScript<Long> subscriptionAppScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/subscription_app.lua"));
+        script.setResultType(Long.class);
         return script;
     }
 }

--- a/src/main/java/hotspot/worker/consumer/consistency/family/consumer/FamilyEventConsumer.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/consumer/FamilyEventConsumer.java
@@ -1,0 +1,34 @@
+package hotspot.worker.consumer.consistency.family.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.worker.consumer.consistency.family.router.FamilyEventRouter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyEventConsumer {
+
+
+    private final FamilyEventRouter router;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "${app.topics.family-events}",
+            groupId = "${app.consumer-groups.family}"
+    )
+    public void consume(String message) throws Exception {
+
+        JsonNode node = objectMapper.readTree(message);
+
+        if (node.isTextual()) {
+            node = objectMapper.readTree(node.asText());
+        }
+
+        router.route(node);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/dto/PriorityDto.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/dto/PriorityDto.java
@@ -1,0 +1,6 @@
+package hotspot.worker.consumer.consistency.family.dto;
+
+public record PriorityDto(
+        long subId,
+        long priority
+) {}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/executor/FamilyLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/executor/FamilyLuaExecutor.java
@@ -1,0 +1,86 @@
+package hotspot.worker.consumer.consistency.family.executor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import hotspot.worker.consumer.consistency.family.dto.PriorityDto;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyLuaExecutor {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private final DefaultRedisScript<Long> familyMemberScript;
+    private final DefaultRedisScript<Long> familyModeScript;
+    private final DefaultRedisScript<Long> familySubLimitScript;
+
+    public void executeMember(String eventId, long familyId, long subId, String type) {
+
+        redisTemplate.execute(
+                familyMemberScript,
+                List.of(
+                        "idem:family:" + eventId,
+                        "limit:family:" + familyId,
+                        "idx:sub:family",
+                        "idx:family:subs:" + familyId,
+                        "limit:family_sub:" + familyId + ":" + subId,
+                        "priority:family:" + familyId
+                ),
+                String.valueOf(subId),
+                String.valueOf(familyId),
+                type
+        );
+    }
+
+    public void executeMode(
+            String eventId,
+            long familyId,
+            String mode,
+            List<PriorityDto> priorities
+    ) {
+
+        List<String> keys = List.of(
+                "idem:family:" + eventId,
+                "priority:family:" + familyId
+        );
+
+        List<String> args = new ArrayList<>();
+        args.add(mode);
+
+        if ("PRIORITY".equals(mode)) {
+
+            args.add(String.valueOf(priorities.size()));
+
+            for (PriorityDto dto : priorities) {
+                args.add(String.valueOf(dto.subId()));
+                args.add(String.valueOf(dto.priority()));
+            }
+
+        } else {
+            args.add("0");
+        }
+
+        redisTemplate.execute(
+                familyModeScript,
+                keys,
+                args.toArray()
+        );
+    }
+
+    public void executeSubLimit(String eventId, long familyId, long subId, long newLimit) {
+        redisTemplate.execute(
+                familySubLimitScript,
+                List.of(
+                        "idem:family:" + eventId,
+                        "limit:family_sub:" + familyId + ":" + subId
+                ),
+                String.valueOf(newLimit)
+        );
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyEventHandler.java
@@ -1,0 +1,10 @@
+package hotspot.worker.consumer.consistency.family.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface FamilyEventHandler {
+
+    boolean supports(String eventType);
+
+    void handle(JsonNode event);
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyMemberHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyMemberHandler.java
@@ -1,0 +1,34 @@
+package hotspot.worker.consumer.consistency.family.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.family.executor.FamilyLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyMemberHandler implements FamilyEventHandler {
+
+    private final FamilyLuaExecutor luaExecutor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("FAMILY_MEMBER_ADDED")
+                || eventType.equals("FAMILY_MEMBER_REMOVED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long familyId = event.get("familyId").asLong();
+        long subId = event.get("subId").asLong();
+
+        String type = event.get("type").asText()
+                .equals("FAMILY_MEMBER_ADDED") ? "ADD" : "REMOVE";
+
+        luaExecutor.executeMember(eventId, familyId, subId, type);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyModeHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilyModeHandler.java
@@ -1,0 +1,48 @@
+package hotspot.worker.consumer.consistency.family.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.family.dto.PriorityDto;
+import hotspot.worker.consumer.consistency.family.executor.FamilyLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyModeHandler implements FamilyEventHandler {
+
+    private final FamilyLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("FAMILY_MODE_CHANGED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long familyId = event.get("familyId").asLong();
+        String mode = event.get("mode").asText();
+
+        List<PriorityDto> priorities = new ArrayList<>();
+
+        if (mode.equals("PRIORITY")) {
+
+            for (JsonNode node : event.get("priorities")) {
+                priorities.add(
+                        new PriorityDto(
+                                node.get("subId").asLong(),
+                                node.get("priority").asLong()
+                        )
+                );
+            }
+        }
+
+        executor.executeMode(eventId, familyId, mode, priorities);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilySubLimitHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/handler/FamilySubLimitHandler.java
@@ -1,0 +1,31 @@
+package hotspot.worker.consumer.consistency.family.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.family.executor.FamilyLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilySubLimitHandler implements FamilyEventHandler {
+
+    private final FamilyLuaExecutor luaExecutor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("FAMILY_SUB_LIMIT_CHANGED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long familyId = event.get("familyId").asLong();
+        long subId = event.get("subId").asLong();
+        long newLimit = event.get("newLimit").asLong();
+
+        luaExecutor.executeSubLimit(eventId, familyId, subId, newLimit);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/family/router/FamilyEventRouter.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/family/router/FamilyEventRouter.java
@@ -1,0 +1,28 @@
+package hotspot.worker.consumer.consistency.family.router;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.family.handler.FamilyEventHandler;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyEventRouter {
+
+    private final List<FamilyEventHandler> handlers;
+
+    public void route(JsonNode event) {
+
+        String type = event.get("type").asText();
+
+        handlers.stream()
+                .filter(h -> h.supports(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No handler for " + type))
+                .handle(event);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/consumer/SubscriptionEventConsumer.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/consumer/SubscriptionEventConsumer.java
@@ -1,0 +1,33 @@
+package hotspot.worker.consumer.consistency.subscription.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.worker.consumer.consistency.subscription.router.SubscriptionEventRouter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionEventConsumer {
+
+    private final SubscriptionEventRouter router;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "${app.topics.subscription-events}",
+            groupId = "${app.consumer-groups.subscription}"
+    )
+    public void consume(String message) throws Exception {
+
+        JsonNode node = objectMapper.readTree(message);
+
+        if (node.isTextual()) {
+            node = objectMapper.readTree(node.asText());
+        }
+
+        router.route(node);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/executor/SubscriptionLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/executor/SubscriptionLuaExecutor.java
@@ -1,0 +1,116 @@
+package hotspot.worker.consumer.consistency.subscription.executor;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionLuaExecutor {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private final DefaultRedisScript<Long> subscriptionLockScript;
+    private final DefaultRedisScript<Long> subscriptionPlanChangedScript;
+    private final DefaultRedisScript<Long> subscriptionPolicyScript;
+    private final DefaultRedisScript<Long> subscriptionGiftScript;
+    private final DefaultRedisScript<Long> subscriptionAppScript;
+
+    public void executeLock(String eventId, long subId, String action) {
+        redisTemplate.execute(
+                subscriptionLockScript,
+                List.of(
+                        "idem:sub:" + eventId,
+                        "block:immediate:" + subId
+                ),
+                action
+        );
+    }
+
+    public void executePlanChanged(String eventId, long subId, long limit) {
+        redisTemplate.execute(
+                subscriptionPlanChangedScript,
+                List.of(
+                        "idem:sub:" + eventId,
+                        "limit:sub:" + subId
+                ),
+                String.valueOf(limit)
+        );
+    }
+
+    public void executePolicy(
+            String eventId,
+            long subId,
+            String action,
+            String policyType,
+            long policyId,
+            String encoded,
+            Long expireEpoch
+    ) {
+        redisTemplate.execute(
+                subscriptionPolicyScript,
+                List.of(
+                        "idem:sub:" + eventId,
+                        "block:repeat:" + subId,
+                        "block:time:" + subId
+                ),
+                action,
+                policyType,
+                String.valueOf(policyId),
+                encoded == null ? "" : encoded,
+                expireEpoch == null ? "0" : String.valueOf(expireEpoch)
+        );
+    }
+
+    public void executeGift(
+            String eventId,
+            long receiverSubId,
+            long giftId,
+            String yyyyMM,
+            long giftLimitBytes,
+            long giverSubId,
+            String yyyyMMDD,
+            long giftAmountBytes
+    ) {
+
+        List<String> keys = List.of(
+                "idem:sub:" + eventId,
+                "limit:gift:" + receiverSubId + ":" + giftId + ":" + yyyyMM,
+                "idx:gift:" + receiverSubId + ":" + yyyyMM,
+                "usage:sub:" + giverSubId + ":" + yyyyMM,
+                "usage:sub:" + giverSubId + ":" + yyyyMMDD
+        );
+
+        redisTemplate.execute(
+                subscriptionGiftScript,
+                keys,
+                String.valueOf(giftId),
+                String.valueOf(giftLimitBytes),
+                String.valueOf(giftAmountBytes),
+                "plan_used",
+                yyyyMM,
+                yyyyMMDD
+        );
+    }
+
+    public void executeAppPolicy(
+            String eventId,
+            long subId,
+            String action,
+            long appId
+    ) {
+        redisTemplate.execute(
+                subscriptionAppScript,
+                List.of(
+                        "idem:sub:" + eventId,
+                        "block:app:" + subId
+                ),
+                action,
+                String.valueOf(appId)
+        );
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/AppPolicyHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/AppPolicyHandler.java
@@ -1,0 +1,34 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.executor.SubscriptionLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppPolicyHandler implements SubscriptionEventHandler {
+
+    private final SubscriptionLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("APP_BLOCKED")
+                || eventType.equals("APP_UNBLOCKED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long subId = event.get("subId").asLong();
+        long appId = event.get("appId").asLong();
+        String type = event.get("type").asText();
+
+        String action = type.equals("APP_BLOCKED") ? "APPLY" : "REMOVE";
+
+        executor.executeAppPolicy(eventId, subId, action, appId);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/GiftHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/GiftHandler.java
@@ -1,0 +1,47 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.executor.SubscriptionLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GiftHandler implements SubscriptionEventHandler {
+
+    private final SubscriptionLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("GIFT_RECEIVED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+
+        long receiverSubId = event.get("receiverSubId").asLong();
+        long giverSubId = event.get("giverSubId").asLong();
+
+        long giftId = event.get("giftId").asLong();
+        long giftLimitBytes = event.get("giftLimitBytes").asLong();
+        long giftAmountBytes = event.get("giftAmountBytes").asLong();
+
+        String yyyyMM = event.get("yyyyMM").asText();
+        String yyyyMMDD = event.get("yyyyMMDD").asText();
+
+        executor.executeGift(
+                eventId,
+                receiverSubId,
+                giftId,
+                yyyyMM,
+                giftLimitBytes,
+                giverSubId,
+                yyyyMMDD,
+                giftAmountBytes
+        );
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/PlanChangedHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/PlanChangedHandler.java
@@ -1,0 +1,30 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.executor.SubscriptionLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PlanChangedHandler implements SubscriptionEventHandler {
+
+    private final SubscriptionLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("PLAN_CHANGED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long subId = event.get("subId").asLong();
+        long limit = event.get("planLimit").asLong();
+
+        executor.executePlanChanged(eventId, subId, limit);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/PolicyHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/PolicyHandler.java
@@ -1,0 +1,71 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.executor.SubscriptionLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PolicyHandler implements SubscriptionEventHandler {
+
+    private final SubscriptionLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("POLICY_APPLIED")
+                || eventType.equals("POLICY_REMOVED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long subId = event.get("subId").asLong();
+        long policyId = event.get("policyId").asLong();
+        String type = event.get("type").asText();
+
+        if (type.equals("POLICY_APPLIED")) {
+
+            String policyType = event.get("policyType").asText();
+
+            if (policyType.equals("SCHEDULED")) {
+
+                executor.executePolicy(
+                        eventId,
+                        subId,
+                        "APPLY",
+                        "SCHEDULED",
+                        policyId,
+                        event.get("encoded").asText(),
+                        null
+                );
+            } else {
+
+                executor.executePolicy(
+                        eventId,
+                        subId,
+                        "APPLY",
+                        "ONCE",
+                        policyId,
+                        null,
+                        event.get("expireEpoch").asLong()
+                );
+            }
+
+        } else {
+
+            executor.executePolicy(
+                    eventId,
+                    subId,
+                    "REMOVE",
+                    "IGNORED",
+                    policyId,
+                    null,
+                    null
+            );
+        }
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/SubscriptionEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/SubscriptionEventHandler.java
@@ -1,0 +1,10 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface SubscriptionEventHandler {
+
+    boolean supports(String eventType);
+
+    void handle(JsonNode event);
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/SubscriptionLockHandler.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/handler/SubscriptionLockHandler.java
@@ -1,0 +1,32 @@
+package hotspot.worker.consumer.consistency.subscription.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.executor.SubscriptionLuaExecutor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionLockHandler implements SubscriptionEventHandler {
+
+    private final SubscriptionLuaExecutor executor;
+
+    @Override
+    public boolean supports(String eventType) {
+        return eventType.equals("SUBSCRIPTION_LOCKED")
+                || eventType.equals("SUBSCRIPTION_UNLOCKED");
+    }
+
+    @Override
+    public void handle(JsonNode event) {
+
+        String eventId = event.get("eventId").asText();
+        long subId = event.get("subId").asLong();
+        String type = event.get("type").asText();
+
+        String action = type.equals("SUBSCRIPTION_LOCKED") ? "LOCK" : "UNLOCK";
+        executor.executeLock(eventId, subId, action);
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/consistency/subscription/router/SubscriptionEventRouter.java
+++ b/src/main/java/hotspot/worker/consumer/consistency/subscription/router/SubscriptionEventRouter.java
@@ -1,0 +1,33 @@
+package hotspot.worker.consumer.consistency.subscription.router;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import hotspot.worker.consumer.consistency.subscription.handler.SubscriptionEventHandler;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriptionEventRouter {
+
+    private final List<SubscriptionEventHandler> handlers;
+
+    public void route(JsonNode event) {
+
+        JsonNode typeNode = event.get("type");
+        if (typeNode == null || !typeNode.isTextual()) {
+            throw new IllegalArgumentException("Missing or invalid 'type' field: " + event);
+        }
+
+        String type = typeNode.asText();
+
+        handlers.stream()
+                .filter(h -> h.supports(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No handler for " + type))
+                .handle(event);
+    }
+}

--- a/src/main/resources/kafka.yml
+++ b/src/main/resources/kafka.yml
@@ -16,7 +16,6 @@ spring:
         batch.size: 32768
 
     consumer:
-      group-id: ${KAFKA_CONSUMER_GROUP_ID:usage-consumer-group}
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       auto-offset-reset: earliest
@@ -29,7 +28,11 @@ app:
   topics:
     usage-events: usage-events
     usage-alert-events: usage-alert-events
+    family-events: family-events
+    subscription-events: subscription-events
 
   consumer-groups:
     usage: usage-consumer-group
     alert: usage-alert-consumer-group
+    family: family-consumer-group
+    subscription: subscription-consumer-group

--- a/src/main/resources/lua/family_member.lua
+++ b/src/main/resources/lua/family_member.lua
@@ -1,0 +1,93 @@
+-- KEYS:
+-- 1) idemKey                        idem:family:{eventId}
+-- 2) familyLimitKey                 limit:family:{familyId}
+-- 3) subFamilyKey                   idx:sub:family
+-- 4) familySubsKey                  idx:family:subs:{familyId}
+-- 5) familySubLimitKey              limit:family_sub:{familyId}:{subId}
+-- 6) priorityKey                    priority:family:{familyId}
+
+-- ARGV:
+-- 1) subId
+-- 2) familyId
+-- 3) eventType                      ADD | REMOVE
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+local subId = ARGV[1]
+local familyId = ARGV[2]
+local eventType = ARGV[3]
+
+local LIMIT_PER_MEMBER = 5 * 1024 * 1024
+
+if eventType == 'ADD' then
+
+	local added = redis.call('SADD', KEYS[4], subId)
+
+	if added == 1 then
+
+	-- sub ↔ family 매핑
+		redis.call('HSET', KEYS[3], subId, familyId)
+
+		-- family_limit 증가
+		redis.call('HINCRBY', KEYS[2], 'family_limit', LIMIT_PER_MEMBER)
+
+		-- 증가된 family_limit 조회
+		local newLimit = redis.call('HGET', KEYS[2], 'family_limit')
+
+		-- 개인별 가족 한도 저장
+		redis.call('HSET', KEYS[5], 'family_limit', newLimit)
+
+		-- PRIORITY 모드일 경우 자동 우선순위 추가
+		if redis.call('EXISTS', KEYS[6]) == 1 then
+			local maxScore = redis.call('ZREVRANGE', KEYS[6], 0, 0, 'WITHSCORES')
+			local nextScore = 0
+
+			if #maxScore > 0 then
+				nextScore = tonumber(maxScore[2]) + 1
+			end
+
+			redis.call('ZADD', KEYS[6], nextScore, subId)
+		end
+	end
+
+else
+
+	local removed = redis.call('SREM', KEYS[4], subId)
+
+	if removed == 1 then
+
+		redis.call('HDEL', KEYS[3], subId)
+
+		local current = tonumber(redis.call('HGET', KEYS[2], 'family_limit') or '0')
+		local newVal = current - LIMIT_PER_MEMBER
+		if newVal < 0 then newVal = 0 end
+
+		redis.call('HSET', KEYS[2], 'family_limit', newVal)
+
+		redis.call('DEL', KEYS[5])
+
+		-- 🔥 PRIORITY 재정렬 포함
+		if redis.call('EXISTS', KEYS[6]) == 1 then
+
+			local oldScore = redis.call('ZSCORE', KEYS[6], subId)
+
+			if oldScore then
+
+				redis.call('ZREM', KEYS[6], subId)
+
+				local members = redis.call('ZRANGEBYSCORE', KEYS[6], '(' .. oldScore, '+inf', 'WITHSCORES')
+
+				for i = 1, #members, 2 do
+					local member = members[i]
+					local score = tonumber(members[i+1])
+					redis.call('ZADD', KEYS[6], score - 1, member)
+				end
+			end
+		end
+	end
+end
+
+return 1

--- a/src/main/resources/lua/family_member.lua
+++ b/src/main/resources/lua/family_member.lua
@@ -28,16 +28,12 @@ if eventType == 'ADD' then
 
 	if added == 1 then
 
-	-- sub ↔ family 매핑
 		redis.call('HSET', KEYS[3], subId, familyId)
 
-		-- family_limit 증가
 		redis.call('HINCRBY', KEYS[2], 'family_limit', LIMIT_PER_MEMBER)
 
-		-- 증가된 family_limit 조회
 		local newLimit = redis.call('HGET', KEYS[2], 'family_limit')
 
-		-- 개인별 가족 한도 저장
 		redis.call('HSET', KEYS[5], 'family_limit', newLimit)
 
 		-- PRIORITY 모드일 경우 자동 우선순위 추가
@@ -69,7 +65,6 @@ else
 
 		redis.call('DEL', KEYS[5])
 
-		-- 🔥 PRIORITY 재정렬 포함
 		if redis.call('EXISTS', KEYS[6]) == 1 then
 
 			local oldScore = redis.call('ZSCORE', KEYS[6], subId)

--- a/src/main/resources/lua/family_mode.lua
+++ b/src/main/resources/lua/family_mode.lua
@@ -1,0 +1,36 @@
+-- KEYS:
+-- 1) idemKey
+-- 2) priorityKey            priority:family:{familyId}
+--
+-- ARGV:
+-- 1) mode                   PRIORITY | FIFO
+-- 2) memberCount
+-- 3...) subId, priority 반복
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+local mode = ARGV[1]
+
+if mode == 'FIFO' then
+	redis.call('DEL', KEYS[2])
+	return 1
+end
+
+-- PRIORITY 모드일 경우
+-- 기존 우선순위 전부 삭제
+redis.call('DEL', KEYS[2])
+
+local count = tonumber(ARGV[2])
+local index = 3
+
+for i = 1, count do
+	local subId = ARGV[index]
+	local priority = tonumber(ARGV[index + 1])
+	redis.call('ZADD', KEYS[2], priority, subId)
+	index = index + 2
+end
+
+return 1

--- a/src/main/resources/lua/family_sub_limit.lua
+++ b/src/main/resources/lua/family_sub_limit.lua
@@ -1,0 +1,15 @@
+-- KEYS:
+-- 1) idemKey
+-- 2) familySubLimitKey
+
+-- ARGV:
+-- 1) newLimit
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+redis.call('HSET', KEYS[2], 'family_limit', tonumber(ARGV[1]))
+
+return 1

--- a/src/main/resources/lua/subscription_app.lua
+++ b/src/main/resources/lua/subscription_app.lua
@@ -1,0 +1,23 @@
+-- KEYS:
+-- 1) idemKey            idem:sub:{eventId}
+-- 2) appBlockKey        block:app:{subId}
+--
+-- ARGV:
+-- 1) action             APPLY | REMOVE
+-- 2) appId
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+local action = ARGV[1]
+local appId = ARGV[2]
+
+if action == 'APPLY' then
+	redis.call('SADD', KEYS[2], appId)
+else
+	redis.call('SREM', KEYS[2], appId)
+end
+
+return 1

--- a/src/main/resources/lua/subscription_gift.lua
+++ b/src/main/resources/lua/subscription_gift.lua
@@ -1,0 +1,49 @@
+-- KEYS:
+-- 1) idemKey                 idem:sub:{eventId}
+-- 2) receiverGiftLimitKey    limit:gift:{receiverSubId}:{giftId}:{yyyyMM}
+-- 3) receiverGiftIdxKey      idx:gift:{receiverSubId}:{yyyyMM}        (ZSET)
+-- 4) giverMonthUsageKey      usage:sub:{giverSubId}:{YYYYMM}          (HASH)
+-- 5) giverDayUsageKey        usage:sub:{giverSubId}:{YYYYMMDD}        (HASH)
+
+-- ARGV:
+-- 1) giftId                  (string/number)
+-- 2) giftLimitBytes          (number)  -- 수신자에게 생성되는 gift 버킷 한도(=선물로 받은 양)
+-- 3) giftAmountBytes         (number)  -- 발신자 사용량에 더할 값(=선물로 준 양)
+-- 4) usageField              (string)  -- 예: "plan_used" (너 지금 plan_used 쓰는 구조)
+-- 5) yyyyMM                  (string)  -- 수신자 idx key에도 들어가지만 혹시 검증/확장용
+-- 6) yyyyMMDD                (string)  -- idem/검증/확장용 (현재는 key에 이미 반영됨)
+
+-- 0) 멱등키(중복 이벤트 방지)
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+-- 1) 수신자 gift 버킷 저장 (giftId별 한도)
+--    ex) HSET limit:gift:10023:901:202602 gift_limit 1048576
+redis.call('HSET', KEYS[2], 'gift_limit', tonumber(ARGV[2]))
+
+-- 2) 수신자 gift 소진 순서 ZSET에 "맨 뒤에" 붙이기 (score 연속 보장)
+--    - 현재 ZSET의 최대 score를 읽고 +1
+--    - 아무것도 없으면 0부터 시작
+local maxScore = redis.call('ZREVRANGE', KEYS[3], 0, 0, 'WITHSCORES')
+local nextScore = 0
+if #maxScore > 0 then
+	nextScore = tonumber(maxScore[2]) + 1
+end
+
+-- 멤버는 giftId로 저장 (각 gift는 1번만 등록된다고 가정)
+-- 이미 존재하면 score 갱신될 수 있으니 안전장치(선택):
+-- "이미 있으면" 새로 append 하지 않고 종료하고 싶으면 아래 2줄을 추가할 수 있음.
+-- local exists = redis.call('ZSCORE', KEYS[3], ARGV[1])
+-- if exists then return 1 end
+
+redis.call('ZADD', KEYS[3], nextScore, ARGV[1])
+
+-- 3) 발신자 월 사용량 증가
+redis.call('HINCRBY', KEYS[4], ARGV[4], tonumber(ARGV[3]))
+
+-- 4) 발신자 일 사용량 증가
+redis.call('HINCRBY', KEYS[5], ARGV[4], tonumber(ARGV[3]))
+
+return 1

--- a/src/main/resources/lua/subscription_lock.lua
+++ b/src/main/resources/lua/subscription_lock.lua
@@ -1,0 +1,21 @@
+-- KEYS:
+-- 1) idemKey               idem:sub:{eventId}
+-- 2) immediateBlockKey     block:immediate:{subId}
+--
+-- ARGV:
+-- 1) action                LOCK | UNLOCK
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+local action = ARGV[1]
+
+if action == 'LOCK' then
+	redis.call('SET', KEYS[2], '1')
+else
+	redis.call('DEL', KEYS[2])
+end
+
+return 1

--- a/src/main/resources/lua/subscription_plan_changed.lua
+++ b/src/main/resources/lua/subscription_plan_changed.lua
@@ -1,0 +1,14 @@
+-- KEYS:
+-- 1) idemKey         idem:sub:{eventId}
+-- 2) planLimitKey    limit:sub:{subId}
+--
+-- ARGV:
+-- 1) planLimit
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+redis.call('HSET', KEYS[2], 'plan_limit', tonumber(ARGV[1]))
+return 1

--- a/src/main/resources/lua/subscription_policy.lua
+++ b/src/main/resources/lua/subscription_policy.lua
@@ -1,0 +1,36 @@
+-- KEYS:
+-- 1) idemKey         idem:sub:{eventId}
+-- 2) repeatKey       block:repeat:{subId}
+-- 3) timeKey         block:time:{subId}
+--
+-- ARGV:
+-- 1) action          APPLY | REMOVE
+-- 2) policyType      SCHEDULED | ONCE   (REMOVE면 무시 가능)
+-- 3) policyId
+-- 4) encoded         (SCHEDULED일 때만 사용)
+-- 5) expireEpoch     (ONCE일 때만 사용)
+
+local ok = redis.call('SET', KEYS[1], '1', 'NX')
+if not ok then
+	return 0
+end
+
+local action = ARGV[1]
+local policyType = ARGV[2]
+local policyId = ARGV[3]
+
+if action == 'APPLY' then
+	if policyType == 'SCHEDULED' then
+		local encoded = ARGV[4]
+		redis.call('HSET', KEYS[2], policyId, encoded)
+	else
+		local expireEpoch = tonumber(ARGV[5])
+		redis.call('ZADD', KEYS[3], expireEpoch, policyId)
+	end
+else
+-- 제거는 둘 다 시도 (정합성 안전)
+	redis.call('HDEL', KEYS[2], policyId)
+	redis.call('ZREM', KEYS[3], policyId)
+end
+
+return 1


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-112

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성 -->
예) --> Closes #23 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
RDB와 Redis 정합성 Consumer 로직을 구현하였습니다.

             RDB (Outbox)
                      │
                      ▼
                   Kafka
        subscription-events
        family-events
                      ▼
          EventConsumer
        (Subscription / Family)
                      │
                      ▼
              EventRouter
            (type 기반 분기)
                      │
                      ▼
             EventHandler
        (도메인별 Handler 구현체)
                      │
                      ▼
             LuaExecutor
                      │
                      ▼
              Redis Lua
          (Atomic + Idempotent)
                      │
                      ▼
              Redis State

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 관련 테스트 코드를 작성했습니다.
- [ ] 기존 테스트가 모두 통과합니다.
- [ ] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [ ] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
