### PR TITLE
[HOTSPOT-131] 사용량 임계치 알림 이벤트 비동기 전환

### DIFF
--- a/src/main/java/hotspot/worker/common/config/kafka/consumer/OutboxAsyncConfig.java
+++ b/src/main/java/hotspot/worker/common/config/kafka/consumer/OutboxAsyncConfig.java
@@ -1,0 +1,27 @@
+package hotspot.worker.common.config.kafka.consumer;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class OutboxAsyncConfig {
+
+    // Outbox Kafka 콜백(ACK/실패처리) 전용 실행기
+    @Bean(name = "outboxAlertCallbackExecutor")
+    public Executor outboxAlertCallbackExecutor(
+            @Value("${app.outbox.usage-alerts.callback-executor.pool-size:4}") int poolSize,
+            @Value("${app.outbox.usage-alerts.callback-executor.queue-capacity:1000}") int queueCapacity
+    ) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(poolSize);
+        executor.setMaxPoolSize(poolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("outbox-alert-callback-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/hotspot/worker/consumer/usage/service/OutboxAlertPublisher.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/OutboxAlertPublisher.java
@@ -6,9 +6,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 
 import jakarta.annotation.PostConstruct;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.RedisStreamCommands;
@@ -44,6 +47,8 @@ public class OutboxAlertPublisher {
     private final StringRedisTemplate redis;
     private final KafkaTemplate<String, UsageAlertEvent> kafka;
     private final ObjectMapper om;
+    private final Executor callbackExecutor;
+    private final Semaphore inFlight;
 
     private final String topic;
     private final String streamKey;
@@ -73,11 +78,15 @@ public class OutboxAlertPublisher {
             @Value("${app.outbox.usage-alerts.max-attempts:20}") int maxAttempts,
             @Value("${app.outbox.usage-alerts.meta-ttl-seconds:1209600}") long metaTtlSeconds,
             @Value("${app.outbox.usage-alerts.reclaim-min-idle-ms:60000}") long reclaimMinIdleMs,
-            @Value("${app.outbox.usage-alerts.reclaim-batch-size:100}") long reclaimBatchSize
+            @Value("${app.outbox.usage-alerts.reclaim-batch-size:100}") long reclaimBatchSize,
+            @Value("${app.outbox.usage-alerts.max-in-flight:500}") int maxInFlight,
+            @Qualifier("outboxAlertCallbackExecutor") Executor callbackExecutor
     ) {
         this.redis = redis;
         this.kafka = kafka;
         this.om = om;
+        this.callbackExecutor = callbackExecutor;
+        this.inFlight = new Semaphore(maxInFlight);
         this.topic = topic;
         this.streamKey = streamKey;
         this.dlqStreamKey = dlqStreamKey;
@@ -94,17 +103,23 @@ public class OutboxAlertPublisher {
 
     @PostConstruct
     public void initializeConsumerGroup() {
-        // 애플리케이션 기동 시 consumer group 보장
         ensureGroup();
     }
 
     // 신규 outbox 엔트리 발행 + reclaim 루프
     @Scheduled(fixedDelayString = "${app.outbox.usage-alerts.poll-delay-ms:500}")
     public void publishFromOutbox() {
+        // 비동기 전송 상한에 도달하면 다음 스케줄 주기에 처리한다.
+        int availableForNew = inFlight.availablePermits();
+        if (availableForNew <= 0) {
+            return;
+        }
+
+        long newReadCount = Math.min(readCount, availableForNew);
         List<MapRecord<String, Object, Object>> newRecords = redis.opsForStream().read(
                 Consumer.from(group, consumerName),
                 StreamReadOptions.empty()
-                        .count(readCount)
+                        .count(newReadCount)
                         .block(Duration.ofMillis(blockMs)),
                 StreamOffset.create(streamKey, ReadOffset.lastConsumed())
         );
@@ -115,13 +130,22 @@ public class OutboxAlertPublisher {
 
     // 죽은 consumer가 남긴 pending 엔트리를 재할당
     private void reclaimPending() {
-        PendingMessages pending = redis.opsForStream().pending(streamKey, group, Range.unbounded(), reclaimBatchSize);
+        int availableForReclaim = inFlight.availablePermits();
+        if (availableForReclaim <= 0) {
+            return;
+        }
+
+        long pendingReadCount = Math.min(reclaimBatchSize, availableForReclaim);
+        PendingMessages pending = redis.opsForStream().pending(streamKey, group, Range.unbounded(), pendingReadCount);
         if (pending == null || pending.isEmpty()) {
             return;
         }
 
-        List<RecordId> staleIds = new ArrayList<>();
+        List<RecordId> staleIds = new ArrayList<>(availableForReclaim);
         for (PendingMessage msg : pending) {
+            if (staleIds.size() >= availableForReclaim) {
+                break;
+            }
             Duration elapsed = msg.getElapsedTimeSinceLastDelivery();
             if (elapsed != null && elapsed.toMillis() >= reclaimMinIdleMs) {
                 staleIds.add(msg.getId());
@@ -167,10 +191,26 @@ public class OutboxAlertPublisher {
 
         try {
             UsageAlertEvent event = om.readValue(payload, UsageAlertEvent.class);
-            kafka.send(topic, kafkaKey, event).join();
+            // permit 획득에 실패하면 ACK 없이 두어 다음 주기에서 재처리한다.
+            if (!inFlight.tryAcquire()) {
+                return;
+            }
 
-            redis.opsForStream().acknowledge(streamKey, group, record.getId());
-            redis.delete(metaKey(streamId));
+            // 스케줄러 스레드를 막지 않도록 콜백에서 후처리를 수행한다.
+            kafka.send(topic, kafkaKey, event).whenCompleteAsync((result, ex) -> {
+                try {
+                    if (ex == null) {
+                        redis.opsForStream().acknowledge(streamKey, group, record.getId());
+                        redis.delete(metaKey(streamId));
+                        return;
+                    }
+                    handleFailure(record, asException(ex));
+                } catch (Exception callbackError) {
+                    handleFailure(record, callbackError);
+                } finally {
+                    inFlight.release();
+                }
+            }, callbackExecutor);
         } catch (Exception e) {
             handleFailure(record, e);
         }
@@ -253,6 +293,13 @@ public class OutboxAlertPublisher {
 
     private String asString(Object value) {
         return value == null ? null : String.valueOf(value);
+    }
+
+    private Exception asException(Throwable t) {
+        if (t instanceof Exception ex) {
+            return ex;
+        }
+        return new RuntimeException(t);
     }
 
     private boolean isBusyGroup(Exception e) {

--- a/src/main/java/hotspot/worker/consumer/usage/service/OutboxAlertPublisher.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/OutboxAlertPublisher.java
@@ -189,12 +189,14 @@ public class OutboxAlertPublisher {
             return;
         }
 
+        boolean acquired = false;
         try {
             UsageAlertEvent event = om.readValue(payload, UsageAlertEvent.class);
             // permit 획득에 실패하면 ACK 없이 두어 다음 주기에서 재처리한다.
             if (!inFlight.tryAcquire()) {
                 return;
             }
+            acquired = true;
 
             // 스케줄러 스레드를 막지 않도록 콜백에서 후처리를 수행한다.
             kafka.send(topic, kafkaKey, event).whenCompleteAsync((result, ex) -> {
@@ -211,8 +213,13 @@ public class OutboxAlertPublisher {
                     inFlight.release();
                 }
             }, callbackExecutor);
+            acquired = false;
         } catch (Exception e) {
             handleFailure(record, e);
+        } finally {
+            if (acquired) {
+                inFlight.release();
+            }
         }
     }
 

--- a/src/main/resources/kafka.yml
+++ b/src/main/resources/kafka.yml
@@ -46,8 +46,12 @@ app:
       block-ms: 2000
       poll-delay-ms: 500
       max-attempts: 20
+      max-in-flight: 500
       meta-key-prefix: "outbox:meta:usage-alerts:v1:"
       meta-ttl-seconds: 1209600
       dlq-stream-key: outbox:usage-alerts:dlq:v1
       reclaim-min-idle-ms: 60000
       reclaim-batch-size: 100
+      callback-executor:
+        pool-size: 4
+        queue-capacity: 1000


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-131

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #28 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- OutboxAlertPublisher join() 제거 및 whenCompleteAsync 적용
- in-flight 제한용 Semaphore 추가
- Kafka 콜백 전용 Executor Bean 추가
- 설정값 추가
  - max-in-flight
  - callback-pool-size
  - send-timeout-ms
- reclaim/재시도 파라미터 정합성 조정
- 재시도/backoff 기본값 및 중복 발행 가능 구간 최소화
- 통합 테스트/검증

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
