### PR TITLE
[HOTSPOT-287] 시간대별 데이터 사용량 집계 로직 구현

### DIFF
--- a/src/main/java/hotspot/seed/SeedRunner.java
+++ b/src/main/java/hotspot/seed/SeedRunner.java
@@ -55,6 +55,7 @@ public class SeedRunner {
             deleteByPattern(redis, "usage:family:*");
             deleteByPattern(redis, "usage:gift:*");
             deleteByPattern(redis, "usage:app:*");
+            deleteByPattern(redis, "usage:3hourly:*");
             deleteByPattern(redis, "notify:sub:*");
             deleteByPattern(redis, "notify:family:*");
             deleteByPattern(redis, "notify:gift:*");
@@ -257,6 +258,13 @@ public class SeedRunner {
 
             String donorDayAppKey = "usage:app:" + row.provideSubId() + ":" + yyyymmdd;
             conn.zIncrBy(b(donorDayAppKey), row.dataAmountKb(), b(giftAppId));
+
+            String donorDay3HourlyAppKey = "usage:3hourly:" + row.provideSubId() + ":" + yyyymmdd;
+            conn.hIncrBy(
+                    b(donorDay3HourlyAppKey),
+                    b(daily3HourlyUsedField(row.createdTime())),
+                    row.dataAmountKb()
+            );
 
             String usageGiftKey = "usage:gift:" + row.targetSubId() + ":" + giftId + ":" + yyyymm;
             conn.hSetNX(b(usageGiftKey), b("gift_used"), b("0"));
@@ -506,5 +514,10 @@ public class SeedRunner {
     }
 
     private record BlockAppRow(long subId, String appId) {
+    }
+
+    private static String daily3HourlyUsedField(LocalDateTime ts) {
+        int bucketHour = (ts.getHour() / 3) * 3;
+        return String.format("%02d_used", bucketHour);
     }
 }

--- a/src/main/java/hotspot/seed/SeedRunner.java
+++ b/src/main/java/hotspot/seed/SeedRunner.java
@@ -22,6 +22,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.StringUtils;
 
+import hotspot.worker.consumer.usage.support.TimeKey;
+
 /**
  * 로컬 Redis에 정책/한도 시드 데이터를 적재하는 전용 실행기
  */
@@ -262,7 +264,7 @@ public class SeedRunner {
             String donorDay3HourlyAppKey = "usage:3hourly:" + row.provideSubId() + ":" + yyyymmdd;
             conn.hIncrBy(
                     b(donorDay3HourlyAppKey),
-                    b(daily3HourlyUsedField(row.createdTime())),
+                    b(TimeKey.daily3HourlyUsedField(row.createdTime().atZone(KST).toInstant(), KST)),
                     row.dataAmountKb()
             );
 
@@ -516,8 +518,4 @@ public class SeedRunner {
     private record BlockAppRow(long subId, String appId) {
     }
 
-    private static String daily3HourlyUsedField(LocalDateTime ts) {
-        int bucketHour = (ts.getHour() / 3) * 3;
-        return String.format("%02d_used", bucketHour);
-    }
 }

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
@@ -1,5 +1,7 @@
 package hotspot.worker.consumer.usage.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import hotspot.worker.consumer.usage.domain.UsageLuaResult;
@@ -9,6 +11,8 @@ import hotspot.worker.outbox.service.UsageAlertOutboxAppender;
 @Service
 public class UsageEventHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(UsageEventHandler.class);
+
     private final UsageLuaExecutor lua;
     private final UsageAlertOutboxAppender outboxAppender;
 
@@ -17,8 +21,16 @@ public class UsageEventHandler {
         this.outboxAppender = outboxAppender;
     }
 
-    // 사용량 이벤트를 Lua로 처리한 뒤 중복이면 종료하고, 중복이 아니면 임계치 결과를 Outbox에 적재한다.
+    // 사용량 이벤트를 Lua로 처리한다. 중복 또는 무효 이벤트면 종료하고, 유효하면 결과를 Outbox에 적재한다.
     public void handle(UsageEvent ev) {
+        if (ev.bytes() <= 0) {
+            log.warn(
+                    "Ignore usage event due to non-positive bytes. eventId={}, subId={}, bytes={}",
+                    ev.eventId(), ev.subId(), ev.bytes()
+            );
+            return;
+        }
+
         UsageLuaResult result = lua.execute(ev);
         if (result.duplicate()) {
             return;

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
@@ -74,16 +74,14 @@ public class UsageLuaExecutor {
 
         // dedup 키가 이미 존재하면 DUP 상태로 반환됨
         if (arr.size() == 1 && "DUP".equals(toStr(arr.get(0)))) {
-            return new UsageLuaResult(
-                    true,
-                    0, 0, 0, 0, 0,
-                    false, 101, 0, 0,
-                    false, 101, 0, 0,
-                    List.of()
-            );
+            return ignoredResult();
         }
 
         String status = toStr(arr.get(0));
+        if ("INVALID_BYTES".equals(status)) {
+            // 비정상 bytes 이벤트는 집계를 건드리지 않고 무시한다.
+            return ignoredResult();
+        }
         if (!"OK".equals(status)) {
             throw new IllegalStateException("Lua returned unexpected status: " + status);
         }
@@ -113,6 +111,16 @@ public class UsageLuaExecutor {
                 planFire, planTh, planRem, planPct,
                 famFire, famTh, famRem, famPct,
                 giftFires
+        );
+    }
+
+    private UsageLuaResult ignoredResult() {
+        return new UsageLuaResult(
+                true,
+                0, 0, 0, 0, 0,
+                false, 101, 0, 0,
+                false, 101, 0, 0,
+                List.of()
         );
     }
 

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
@@ -22,8 +22,8 @@ import hotspot.worker.consumer.usage.support.RedisKeyBuilder;
 @Service
 public class UsageLuaExecutor {
 
-    private static final long TTL_MON_SECONDS = 2_678_400L;
-    private static final long TTL_DAY_SECONDS = 172_800L;
+    private static final long TTL_MON_SECONDS = 15_552_000L;
+    private static final long TTL_DAY_SECONDS = 15_552_000L;
     private static final long TTL_NOTIFY_SECONDS = 2_678_400L;
     private static final long TTL_DEDUP_SECONDS = 86_400L;
 
@@ -63,7 +63,8 @@ public class UsageLuaExecutor {
                 ev.eventId(),
                 ev.occurredAt().toString(),
                 String.valueOf(ev.subId()),
-                String.valueOf(ev.familyId())
+                String.valueOf(ev.familyId()),
+                keysPack.daily3HourlyUsedField()
         );
 
         Object[] argvArray = argv.toArray(new Object[0]);

--- a/src/main/java/hotspot/worker/consumer/usage/support/RedisKeyBuilder.java
+++ b/src/main/java/hotspot/worker/consumer/usage/support/RedisKeyBuilder.java
@@ -18,6 +18,7 @@ public final class RedisKeyBuilder {
     public record Keys(
             List<String> keys,
             String yyyymm,
+            String daily3HourlyUsedField,
             String giftLimitPrefix,
             String giftUsagePrefix,
             String giftNotifyPrefix
@@ -40,6 +41,7 @@ public final class RedisKeyBuilder {
         String usageFamilyDayKey = "usage:family:" + familyId + ":" + yyyymmdd;
         String usageAppMonKey = "usage:app:" + subId + ":" + yyyymm;
         String usageAppDayKey = "usage:app:" + subId + ":" + yyyymmdd;
+        String usageAppDay3HourlyKey = "usage:app:" + subId + ":" + yyyymmdd + ":3hourly";
 
         String notifyPlanMonKey = "notify:sub:" + subId + ":" + yyyymm;
         String notifyPlanDayKey = "notify:sub:" + subId + ":" + yyyymmdd;
@@ -57,6 +59,7 @@ public final class RedisKeyBuilder {
                 usageFamilyDayKey,
                 usageAppMonKey,
                 usageAppDayKey,
+                usageAppDay3HourlyKey,
                 notifyPlanMonKey,
                 notifyPlanDayKey,
                 notifyFamilyMonKey,
@@ -70,6 +73,7 @@ public final class RedisKeyBuilder {
         return new Keys(
                 keys,
                 yyyymm,
+                TimeKey.daily3HourlyUsedField(occurredAt, zone),
                 giftLimitPrefix,
                 giftUsagePrefix,
                 giftNotifyPrefix

--- a/src/main/java/hotspot/worker/consumer/usage/support/RedisKeyBuilder.java
+++ b/src/main/java/hotspot/worker/consumer/usage/support/RedisKeyBuilder.java
@@ -41,7 +41,7 @@ public final class RedisKeyBuilder {
         String usageFamilyDayKey = "usage:family:" + familyId + ":" + yyyymmdd;
         String usageAppMonKey = "usage:app:" + subId + ":" + yyyymm;
         String usageAppDayKey = "usage:app:" + subId + ":" + yyyymmdd;
-        String usageAppDay3HourlyKey = "usage:app:" + subId + ":" + yyyymmdd + ":3hourly";
+        String usage3HourlyDayKey = "usage:3hourly:" + subId + ":" + yyyymmdd;
 
         String notifyPlanMonKey = "notify:sub:" + subId + ":" + yyyymm;
         String notifyPlanDayKey = "notify:sub:" + subId + ":" + yyyymmdd;
@@ -59,7 +59,7 @@ public final class RedisKeyBuilder {
                 usageFamilyDayKey,
                 usageAppMonKey,
                 usageAppDayKey,
-                usageAppDay3HourlyKey,
+                usage3HourlyDayKey,
                 notifyPlanMonKey,
                 notifyPlanDayKey,
                 notifyFamilyMonKey,

--- a/src/main/java/hotspot/worker/consumer/usage/support/TimeKey.java
+++ b/src/main/java/hotspot/worker/consumer/usage/support/TimeKey.java
@@ -24,4 +24,11 @@ public final class TimeKey {
         ZonedDateTime z = ts.atZone(zone);
         return String.format("%04d%02d%02d", z.getYear(), z.getMonthValue(), z.getDayOfMonth());
     }
+
+    // 3시간 버킷 필드명(00_used, 03_used ... 21_used)을 반환
+    public static String daily3HourlyUsedField(Instant ts, ZoneId zone) {
+        ZonedDateTime z = ts.atZone(zone);
+        int bucketHour = (z.getHour() / 3) * 3;
+        return String.format("%02d_used", bucketHour);
+    }
 }

--- a/src/main/resources/lua/usage_atomic.lua
+++ b/src/main/resources/lua/usage_atomic.lua
@@ -58,6 +58,11 @@ local day3HourlyField = ARGV[15]
 local INF = 9007199254740991
 local DAILY_PLAN_LIMIT_KB = 1048576
 
+-- bytes가 비정상(nil/0/음수)이면 사용량 반영 없이 무시한다.
+if bytes == nil or bytes <= 0 then
+  return { "INVALID_BYTES" }
+end
+
 -- dedup 키가 있으면 동일 이벤트이므로 "사용량 반영 + 알림 판단"을 하지 않고 DUP로 종료한다.
 if redis.call('EXISTS', KEYS[15]) == 1 then
   return { "DUP" }

--- a/src/main/resources/lua/usage_atomic.lua
+++ b/src/main/resources/lua/usage_atomic.lua
@@ -11,10 +11,11 @@
 --  8: usage:family:{familyId}:{yyyymmdd}
 --  9: usage:app:{subId}:{yyyymm}
 -- 10: usage:app:{subId}:{yyyymmdd}
--- 11: notify:sub:{subId}:{yyyymm}
--- 12: notify:sub:{subId}:{yyyymmdd}
--- 13: notify:family:{familyId}:{yyyymm}
--- 14: dedup:evt:{eventId}
+-- 11: usage:app:{subId}:{yyyymmdd}:3hourly
+-- 12: notify:sub:{subId}:{yyyymm}
+-- 13: notify:sub:{subId}:{yyyymmdd}
+-- 14: notify:family:{familyId}:{yyyymm}
+-- 15: dedup:evt:{eventId}
 
 -- -------------------------
 -- ARGV
@@ -33,6 +34,7 @@
 -- 12: occurredAt (ISO8601)
 -- 13: subId
 -- 14: familyId
+-- 15: day3HourlyField (00_used, 03_used ... 21_used)
 
 local bytes = tonumber(ARGV[1])
 local appId = ARGV[2]
@@ -52,11 +54,12 @@ local eventId = ARGV[11]
 local occurredAt = ARGV[12]
 local subId = tonumber(ARGV[13])
 local familyId = tonumber(ARGV[14])
+local day3HourlyField = ARGV[15]
 local INF = 9007199254740991
 local DAILY_PLAN_LIMIT_KB = 1048576
 
 -- dedup 키가 있으면 동일 이벤트이므로 "사용량 반영 + 알림 판단"을 하지 않고 DUP로 종료한다.
-if redis.call('EXISTS', KEYS[14]) == 1 then
+if redis.call('EXISTS', KEYS[15]) == 1 then
   return { "DUP" }
 end
 
@@ -232,22 +235,26 @@ redis.call('ZINCRBY', KEYS[10], bytes, appId)
 redis.call('EXPIRE', KEYS[9], ttlMon)
 redis.call('EXPIRE', KEYS[10], ttlDay)
 
+-- 일 단위 3시간 버킷 사용량(usage:app:{subId}:{yyyymmdd}:3hourly)을 HASH로 누적 갱신한다.
+redis.call('HINCRBY', KEYS[11], day3HourlyField, bytes)
+redis.call('EXPIRE', KEYS[11], ttlDay)
+
 -- 선물 인덱스(ZSET)가 월 기간 동안 유지되도록 TTL을 갱신한다.
 redis.call('EXPIRE', KEYS[4], ttlMon)
 
 -- 요금제 임계치 변화를 계산하고 월/일 notify 키를 갱신해 발화 여부를 결정한다.
 local plan_used_new = plan_used_base + plan_take
 local plan_th, plan_rem2, plan_pct = threshold(plan_limit, plan_used_new)
-local plan_fire, plan_last = update_notify(KEYS[11], plan_th)
-update_notify(KEYS[12], plan_th)
+local plan_fire, plan_last = update_notify(KEYS[12], plan_th)
+update_notify(KEYS[13], plan_th)
 
 -- 가족풀 임계치 변화를 계산하고 notify 키를 갱신해 발화 여부를 결정한다.
 local pool_used_new = mon_pool_used + family_take
 local fam_th, fam_rem2, fam_pct = threshold(family_limit_total, pool_used_new)
-local fam_fire, fam_last = update_notify(KEYS[13], fam_th)
+local fam_fire, fam_last = update_notify(KEYS[14], fam_th)
 
 -- 이번 이벤트 처리 완료를 dedup 키로 기록해 중복 처리를 방지한다.
-redis.call('SET', KEYS[14], '1', 'EX', ttlDedup)
+redis.call('SET', KEYS[15], '1', 'EX', ttlDedup)
 
 -- 최종 결과(차감 분배, 임계치 발화 여부/상태, 발화된 선물 목록)를 배열로 반환한다.
 return {

--- a/src/main/resources/lua/usage_atomic.lua
+++ b/src/main/resources/lua/usage_atomic.lua
@@ -11,7 +11,7 @@
 --  8: usage:family:{familyId}:{yyyymmdd}
 --  9: usage:app:{subId}:{yyyymm}
 -- 10: usage:app:{subId}:{yyyymmdd}
--- 11: usage:app:{subId}:{yyyymmdd}:3hourly
+-- 11: usage:3hourly:{subId}:{yyyymmdd}
 -- 12: notify:sub:{subId}:{yyyymm}
 -- 13: notify:sub:{subId}:{yyyymmdd}
 -- 14: notify:family:{familyId}:{yyyymm}
@@ -235,7 +235,7 @@ redis.call('ZINCRBY', KEYS[10], bytes, appId)
 redis.call('EXPIRE', KEYS[9], ttlMon)
 redis.call('EXPIRE', KEYS[10], ttlDay)
 
--- 일 단위 3시간 버킷 사용량(usage:app:{subId}:{yyyymmdd}:3hourly)을 HASH로 누적 갱신한다.
+-- 일 단위 3시간 버킷 사용량(usage:3hourly:{subId}:{yyyymmdd})을 HASH로 누적 갱신한다.
 redis.call('HINCRBY', KEYS[11], day3HourlyField, bytes)
 redis.call('EXPIRE', KEYS[11], ttlDay)
 


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-287

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #49 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 시간대별 사용량 Redis 키/필드 규칙 확정
- usage 이벤트에서 집계 기준 일자 및 시간 버킷 추출 로직 추가
- usage_atomic.lua 수정
  - 기존 일/월 집계와 함께 시간대별 집계 반영
  - HASH에 시간 버킷별 HINCRBY 처리

- 중복 이벤트 처리 시 시간대별 집계도 중복 반영되지 않도록 검증

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
