### PR TITLE
[HOTSPOT-365] Event ACK per-record 로직 개선

### DIFF
--- a/src/main/java/hotspot/worker/common/config/kafka/consumer/KafkaConsumerConfig.java
+++ b/src/main/java/hotspot/worker/common/config/kafka/consumer/KafkaConsumerConfig.java
@@ -39,6 +39,7 @@ public class KafkaConsumerConfig {
 
         factory.setConsumerFactory(usageConsumerFactory);
         factory.setConcurrency(6);
+        factory.setBatchListener(true);
         factory.getContainerProperties()
                 .setAckMode(ContainerProperties.AckMode.MANUAL);
         factory.getContainerProperties().setAsyncAcks(true);

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
@@ -1,5 +1,6 @@
 package hotspot.worker.consumer.usage.service;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
@@ -12,6 +13,7 @@ import hotspot.worker.consumer.usage.schema.UsageEvent;
 import hotspot.worker.outbox.service.UsageAlertOutboxAppender;
 import hotspot.worker.writer.log.dto.UsageAppliedEnvelope;
 import hotspot.worker.writer.log.support.UsageAppliedEventQueue;
+import hotspot.worker.writer.log.support.UsageBatchAcknowledgment;
 
 @Service
 public class UsageEventHandler {
@@ -25,7 +27,6 @@ public class UsageEventHandler {
     private final AtomicLong handledCount = new AtomicLong();
     private final AtomicLong totalHandleNanos = new AtomicLong();
 
-    // 사용량 처리 의존 컴포넌트를 주입받는다.
     public UsageEventHandler(
             UsageLuaExecutor lua,
             UsageAlertOutboxAppender outboxAppender,
@@ -36,32 +37,39 @@ public class UsageEventHandler {
         this.queue = queue;
     }
 
-    // 사용량 이벤트를 Lua로 처리하고 후속 적재 큐에 전달한다.
-    public void handle(UsageEvent ev, Acknowledgment ack) {
-        long start = System.nanoTime();
-        UsageLuaResult result = lua.execute(ev);
-        queue.enqueue(new UsageAppliedEnvelope(
-                ev,
-                result,
-                outboxAppender.buildOutboxEntities(ev, result),
-                outboxAppender.buildAppliedLogEntity(ev, result),
-                ack
-        ));
-        if (result.duplicate()) {
-            log.debug("사용량 이벤트가 중복 또는 무시 처리되었습니다. eventId={}", ev.eventId());
+    public void handle(List<UsageEvent> events, Acknowledgment ack) {
+        if (events == null || events.isEmpty()) {
+            ack.acknowledge();
+            return;
         }
 
-        long elapsedNanos = System.nanoTime() - start;
-        long count = handledCount.incrementAndGet();
-        long total = totalHandleNanos.addAndGet(elapsedNanos);
-        if (count % PERF_LOG_EVERY == 0) {
-            long avgMicros = (total / count) / 1000L;
-            log.info(
-                    "사용량 핸들러 성능 지표입니다. handled={}, avgMicros={}, queueSize={}",
-                    count,
-                    avgMicros,
-                    queue.size()
-            );
+        UsageBatchAcknowledgment batchAcknowledgment = new UsageBatchAcknowledgment(ack, events.size());
+        for (UsageEvent ev : events) {
+            long start = System.nanoTime();
+            UsageLuaResult result = lua.execute(ev);
+            queue.enqueue(new UsageAppliedEnvelope(
+                    ev,
+                    result,
+                    outboxAppender.buildOutboxEntities(ev, result),
+                    outboxAppender.buildAppliedLogEntity(ev, result),
+                    batchAcknowledgment
+            ));
+            if (result.duplicate()) {
+                log.debug("Duplicate usage event ignored. eventId={}", ev.eventId());
+            }
+
+            long elapsedNanos = System.nanoTime() - start;
+            long count = handledCount.incrementAndGet();
+            long total = totalHandleNanos.addAndGet(elapsedNanos);
+            if (count % PERF_LOG_EVERY == 0) {
+                long avgMicros = (total / count) / 1000L;
+                log.info(
+                        "사용량 핸들러 성능 지표입니다. handled={}, avgMicros={}, queueSize={}",
+                        count,
+                        avgMicros,
+                        queue.size()
+                );
+            }
         }
     }
 }

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
@@ -55,7 +55,7 @@ public class UsageEventHandler {
                     batchAcknowledgment
             ));
             if (result.duplicate()) {
-                log.debug("Duplicate usage event ignored. eventId={}", ev.eventId());
+                log.debug("사용량 이벤트가 중복 또는 무시 처리되었습니다. eventId={}", ev.eventId());
             }
 
             long elapsedNanos = System.nanoTime() - start;

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageEventsConsumer.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageEventsConsumer.java
@@ -1,5 +1,7 @@
 package hotspot.worker.consumer.usage.service;
 
+import java.util.List;
+
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -24,7 +26,7 @@ public class UsageEventsConsumer {
             groupId = "${app.consumer-groups.usage}",
             containerFactory = "usageKafkaListenerContainerFactory"
     )
-    public void onMessage(UsageEvent ev, Acknowledgment ack) {
-        handler.handle(ev, ack);
+    public void onMessage(List<UsageEvent> events, Acknowledgment ack) {
+        handler.handle(events, ack);
     }
 }

--- a/src/main/java/hotspot/worker/writer/log/dto/UsageAppliedEnvelope.java
+++ b/src/main/java/hotspot/worker/writer/log/dto/UsageAppliedEnvelope.java
@@ -2,18 +2,17 @@ package hotspot.worker.writer.log.dto;
 
 import java.util.List;
 
-import org.springframework.kafka.support.Acknowledgment;
-
 import hotspot.worker.consumer.usage.domain.UsageLuaResult;
 import hotspot.worker.consumer.usage.schema.UsageEvent;
 import hotspot.worker.outbox.infrastructure.entity.NotificationOutboxEventEntity;
 import hotspot.worker.writer.infrastructure.entity.UsageAppliedEventLogEntity;
+import hotspot.worker.writer.log.support.UsageBatchAcknowledgment;
 
 public record UsageAppliedEnvelope(
         UsageEvent event,
         UsageLuaResult result,
         List<NotificationOutboxEventEntity> outboxEvents,
         UsageAppliedEventLogEntity usageAppliedLog,
-        Acknowledgment acknowledgment
+        UsageBatchAcknowledgment batchAcknowledgment
 ) {
 }

--- a/src/main/java/hotspot/worker/writer/log/service/UsageAppliedLogWriter.java
+++ b/src/main/java/hotspot/worker/writer/log/service/UsageAppliedLogWriter.java
@@ -98,7 +98,7 @@ public class UsageAppliedLogWriter {
 
     private void acknowledgeBatch(List<UsageAppliedEnvelope> batch) {
         for (UsageAppliedEnvelope envelope : batch) {
-            envelope.acknowledgment().acknowledge();
+            envelope.batchAcknowledgment().markPersisted();
         }
     }
 

--- a/src/main/java/hotspot/worker/writer/log/support/UsageBatchAcknowledgment.java
+++ b/src/main/java/hotspot/worker/writer/log/support/UsageBatchAcknowledgment.java
@@ -1,0 +1,28 @@
+package hotspot.worker.writer.log.support;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.kafka.support.Acknowledgment;
+
+public class UsageBatchAcknowledgment {
+
+    private final Acknowledgment acknowledgment;
+    private final AtomicInteger remaining;
+    private final AtomicBoolean acknowledged = new AtomicBoolean(false);
+
+    public UsageBatchAcknowledgment(Acknowledgment acknowledgment, int batchSize) {
+        this.acknowledgment = acknowledgment;
+        this.remaining = new AtomicInteger(batchSize);
+    }
+
+    public void markPersisted() {
+        int left = remaining.decrementAndGet();
+        if (left < 0) {
+            return;
+        }
+        if (left == 0 && acknowledged.compareAndSet(false, true)) {
+            acknowledgment.acknowledge();
+        }
+    }
+}

--- a/src/main/java/hotspot/worker/writer/log/support/UsageBatchAcknowledgment.java
+++ b/src/main/java/hotspot/worker/writer/log/support/UsageBatchAcknowledgment.java
@@ -3,9 +3,13 @@ package hotspot.worker.writer.log.support;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.kafka.support.Acknowledgment;
 
 public class UsageBatchAcknowledgment {
+
+    private static final Logger log = LoggerFactory.getLogger(UsageBatchAcknowledgment.class);
 
     private final Acknowledgment acknowledgment;
     private final AtomicInteger remaining;
@@ -19,6 +23,7 @@ public class UsageBatchAcknowledgment {
     public void markPersisted() {
         int left = remaining.decrementAndGet();
         if (left < 0) {
+            log.error("markPersisted() called more times than batch size. left={}", left);
             return;
         }
         if (left == 0 && acknowledged.compareAndSet(false, true)) {


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-365

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #72 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- Kafka 리스너를 배치 리스너로 전환
- 배치 이벤트 처리 및 배치 ACK 추적 객체 주입 적용
- 이벤트별 acknowledge 호출을 markPersisted 기반으로 전환
- 배치 단일 ACK 보장을 위한 UsageBatchAcknowledgment 구현

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
