### PR TITLE
[HOTSPOT-370] 병목지점 파악을 위한 로그 세분화 구현

### DIFF
--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageEventHandler.java
@@ -1,6 +1,7 @@
 package hotspot.worker.consumer.usage.service;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
@@ -10,11 +11,15 @@ import org.springframework.stereotype.Service;
 
 import hotspot.worker.consumer.usage.domain.UsageLuaResult;
 import hotspot.worker.consumer.usage.schema.UsageEvent;
+import hotspot.worker.outbox.infrastructure.entity.NotificationOutboxEventEntity;
 import hotspot.worker.outbox.service.UsageAlertOutboxAppender;
+import hotspot.worker.writer.infrastructure.entity.UsageAppliedEventLogEntity;
 import hotspot.worker.writer.log.dto.UsageAppliedEnvelope;
 import hotspot.worker.writer.log.support.UsageAppliedEventQueue;
 import hotspot.worker.writer.log.support.UsageBatchAcknowledgment;
 import hotspot.worker.writer.log.support.UsageQueueBackpressureController;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 
 @Service
 public class UsageEventHandler {
@@ -26,19 +31,39 @@ public class UsageEventHandler {
     private final UsageAlertOutboxAppender outboxAppender;
     private final UsageAppliedEventQueue queue;
     private final UsageQueueBackpressureController backpressureController;
+    private final Timer handlerTotalTimer;
+    private final Timer handlerLuaTimer;
+    private final Timer handlerOutboxTimer;
+    private final Timer handlerEnqueueTimer;
     private final AtomicLong handledCount = new AtomicLong();
     private final AtomicLong totalHandleNanos = new AtomicLong();
+    private final AtomicLong totalLuaNanos = new AtomicLong();
+    private final AtomicLong totalOutboxNanos = new AtomicLong();
+    private final AtomicLong totalEnqueueNanos = new AtomicLong();
 
     public UsageEventHandler(
             UsageLuaExecutor lua,
             UsageAlertOutboxAppender outboxAppender,
             UsageAppliedEventQueue queue,
-            UsageQueueBackpressureController backpressureController
+            UsageQueueBackpressureController backpressureController,
+            MeterRegistry meterRegistry
     ) {
         this.lua = lua;
         this.outboxAppender = outboxAppender;
         this.queue = queue;
         this.backpressureController = backpressureController;
+        this.handlerTotalTimer = Timer.builder("hotspot.usage.handler.total")
+                .description("Usage handler total time per event")
+                .register(meterRegistry);
+        this.handlerLuaTimer = Timer.builder("hotspot.usage.handler.lua")
+                .description("Usage handler Lua execution time per event")
+                .register(meterRegistry);
+        this.handlerOutboxTimer = Timer.builder("hotspot.usage.handler.outbox")
+                .description("Usage handler outbox/build entity time per event")
+                .register(meterRegistry);
+        this.handlerEnqueueTimer = Timer.builder("hotspot.usage.handler.enqueue")
+                .description("Usage handler queue enqueue time per event")
+                .register(meterRegistry);
     }
 
     public void handle(List<UsageEvent> events, Acknowledgment ack) {
@@ -58,28 +83,54 @@ public class UsageEventHandler {
         try {
             for (UsageEvent ev : events) {
                 long start = System.nanoTime();
+
+                long luaStart = System.nanoTime();
                 UsageLuaResult result = lua.execute(ev);
+                long luaElapsedNanos = System.nanoTime() - luaStart;
+
+                long outboxStart = System.nanoTime();
+                List<NotificationOutboxEventEntity> outboxEntities = outboxAppender.buildOutboxEntities(ev, result);
+                UsageAppliedEventLogEntity appliedLogEntity = outboxAppender.buildAppliedLogEntity(ev, result);
+                long outboxElapsedNanos = System.nanoTime() - outboxStart;
+
+                long enqueueStart = System.nanoTime();
                 queue.enqueueReserved(new UsageAppliedEnvelope(
                         ev,
                         result,
-                        outboxAppender.buildOutboxEntities(ev, result),
-                        outboxAppender.buildAppliedLogEntity(ev, result),
+                        outboxEntities,
+                        appliedLogEntity,
                         batchAcknowledgment
                 ));
+                long enqueueElapsedNanos = System.nanoTime() - enqueueStart;
+
                 enqueued += 1;
                 if (result.duplicate()) {
-                    log.debug("사용량 이벤트가 중복 또는 무시 처리되었습니다. eventId={}", ev.eventId());
+                    log.debug("사용량 이벤트 중복/무시 처리됨. eventId={}", ev.eventId());
                 }
 
                 long elapsedNanos = System.nanoTime() - start;
+                handlerTotalTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+                handlerLuaTimer.record(luaElapsedNanos, TimeUnit.NANOSECONDS);
+                handlerOutboxTimer.record(outboxElapsedNanos, TimeUnit.NANOSECONDS);
+                handlerEnqueueTimer.record(enqueueElapsedNanos, TimeUnit.NANOSECONDS);
+
                 long count = handledCount.incrementAndGet();
                 long total = totalHandleNanos.addAndGet(elapsedNanos);
+                long totalLua = totalLuaNanos.addAndGet(luaElapsedNanos);
+                long totalOutbox = totalOutboxNanos.addAndGet(outboxElapsedNanos);
+                long totalEnqueue = totalEnqueueNanos.addAndGet(enqueueElapsedNanos);
                 if (count % PERF_LOG_EVERY == 0) {
                     long avgMicros = (total / count) / 1000L;
+                    long avgLuaMicros = (totalLua / count) / 1000L;
+                    long avgOutboxMicros = (totalOutbox / count) / 1000L;
+                    long avgEnqueueMicros = (totalEnqueue / count) / 1000L;
                     log.info(
-                            "사용량 핸들러 성능 지표입니다. handled={}, avgMicros={}, queueSize={}",
+                            "사용량 핸들러 성능 지표: 처리건수={}, 평균처리={}µs, Lua평균={}µs, Outbox평균={}µs, Enqueue평균={}µs, 큐사이즈={}",
                             count,
                             avgMicros,
+                            avgLuaMicros,
+                            avgOutboxMicros,
+                            avgEnqueueMicros,
                             queue.size()
                     );
                 }

--- a/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
+++ b/src/main/java/hotspot/worker/consumer/usage/service/UsageLuaExecutor.java
@@ -2,6 +2,7 @@ package hotspot.worker.consumer.usage.service;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
@@ -19,6 +20,9 @@ import hotspot.worker.consumer.usage.domain.GiftFire;
 import hotspot.worker.consumer.usage.domain.UsageLuaResult;
 import hotspot.worker.consumer.usage.schema.UsageEvent;
 import hotspot.worker.consumer.usage.support.RedisKeyBuilder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 
 @Service
 public class UsageLuaExecutor {
@@ -35,23 +39,48 @@ public class UsageLuaExecutor {
     private final DefaultRedisScript<List> usageAtomicScript;
     private final RedisKeyBuilder keyBuilder;
     private final ObjectMapper om;
+    private final Timer luaTotalTimer;
+    private final Timer luaRedisExecuteTimer;
+    private final Timer luaParseTimer;
+    private final Counter luaStatusOkCounter;
+    private final Counter luaStatusDupCounter;
+    private final Counter luaStatusInvalidBytesCounter;
     private final AtomicLong executedCount = new AtomicLong();
     private final AtomicLong totalExecuteNanos = new AtomicLong();
+    private final AtomicLong totalRedisExecuteNanos = new AtomicLong();
+    private final AtomicLong totalParseNanos = new AtomicLong();
 
-    // Lua 실행과 결과 파싱에 필요한 의존성을 주입받는다.
     public UsageLuaExecutor(
             StringRedisTemplate redis,
             DefaultRedisScript<List> usageAtomicScript,
             RedisKeyBuilder keyBuilder,
-            ObjectMapper om
+            ObjectMapper om,
+            MeterRegistry meterRegistry
     ) {
         this.redis = redis;
         this.usageAtomicScript = usageAtomicScript;
         this.keyBuilder = keyBuilder;
         this.om = om;
+        this.luaTotalTimer = Timer.builder("hotspot.usage.lua.total")
+                .description("Total Lua executor time per event")
+                .register(meterRegistry);
+        this.luaRedisExecuteTimer = Timer.builder("hotspot.usage.lua.redis.execute")
+                .description("Redis EVAL roundtrip time per event")
+                .register(meterRegistry);
+        this.luaParseTimer = Timer.builder("hotspot.usage.lua.parse")
+                .description("Lua response parsing time per event")
+                .register(meterRegistry);
+        this.luaStatusOkCounter = Counter.builder("hotspot.usage.lua.status")
+                .tag("status", "ok")
+                .register(meterRegistry);
+        this.luaStatusDupCounter = Counter.builder("hotspot.usage.lua.status")
+                .tag("status", "dup")
+                .register(meterRegistry);
+        this.luaStatusInvalidBytesCounter = Counter.builder("hotspot.usage.lua.status")
+                .tag("status", "invalid_bytes")
+                .register(meterRegistry);
     }
 
-    // usage 이벤트를 Lua 스크립트로 원자 처리하고 결과를 DTO로 변환한다.
     public UsageLuaResult execute(UsageEvent ev) {
         long start = System.nanoTime();
         RedisKeyBuilder.Keys keysPack =
@@ -77,19 +106,24 @@ public class UsageLuaExecutor {
         );
 
         Object[] argvArray = argv.toArray(new Object[0]);
+        long redisExecuteStart = System.nanoTime();
         Object raw = redis.execute(usageAtomicScript, keysPack.keys(), argvArray);
+        long redisExecuteElapsedNanos = System.nanoTime() - redisExecuteStart;
         @SuppressWarnings("unchecked")
         List<Object> arr = (List<Object>) raw;
 
+        long parseStart = System.nanoTime();
         String status = toStr(arr.get(0));
         UsageLuaResult result;
         if ("INVALID_BYTES".equals(status)) {
             result = ignoredResult();
+            luaStatusInvalidBytesCounter.increment();
         } else if ("DUP".equals(status)) {
             if (arr.size() < 2 || toStr(arr.get(1)) == null || toStr(arr.get(1)).isBlank()) {
                 throw new IllegalStateException("Lua returned DUP without cached result payload");
             }
             result = parseCachedResult(toStr(arr.get(1)));
+            luaStatusDupCounter.increment();
         } else if ("DUP_MISSING_RESULT".equals(status)) {
             throw new IllegalStateException("Lua returned DUP but result cache key is missing");
         } else if (!"OK".equals(status)) {
@@ -127,19 +161,33 @@ public class UsageLuaExecutor {
                     giftFires,
                     giftAllocations
             );
+            luaStatusOkCounter.increment();
         }
+        long parseElapsedNanos = System.nanoTime() - parseStart;
 
         long elapsedNanos = System.nanoTime() - start;
+        luaTotalTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+        luaRedisExecuteTimer.record(redisExecuteElapsedNanos, TimeUnit.NANOSECONDS);
+        luaParseTimer.record(parseElapsedNanos, TimeUnit.NANOSECONDS);
         long count = executedCount.incrementAndGet();
         long totalNanos = totalExecuteNanos.addAndGet(elapsedNanos);
+        long totalRedisNanos = totalRedisExecuteNanos.addAndGet(redisExecuteElapsedNanos);
+        long totalParseNanosValue = totalParseNanos.addAndGet(parseElapsedNanos);
         if (count % PERF_LOG_EVERY == 0) {
             long avgMicros = (totalNanos / count) / 1000L;
-            log.info("Lua 처리 성능 지표입니다. executed={}, avgMicros={}", count, avgMicros);
+            long avgRedisMicros = (totalRedisNanos / count) / 1000L;
+            long avgParseMicros = (totalParseNanosValue / count) / 1000L;
+            log.info(
+                    "Lua 성능 지표: 처리건수={}, 평균처리={}µs, Redis실행평균={}µs, 파싱평균={}µs",
+                    count,
+                    avgMicros,
+                    avgRedisMicros,
+                    avgParseMicros
+            );
         }
         return result;
     }
 
-    // DUP 결과에 포함된 캐시 JSON을 UsageLuaResult로 복원한다.
     private UsageLuaResult parseCachedResult(String json) {
         try {
             JsonNode node = om.readTree(json);
@@ -172,7 +220,6 @@ public class UsageLuaExecutor {
         }
     }
 
-    // INVALID_BYTES 응답을 무시 결과 DTO로 변환한다.
     private UsageLuaResult ignoredResult() {
         return new UsageLuaResult(
                 true,
@@ -185,7 +232,6 @@ public class UsageLuaExecutor {
         );
     }
 
-    // Lua의 fired_gifts JSON 배열을 도메인 리스트로 파싱한다.
     private List<GiftFire> parseGiftFires(String json) {
         if (json == null || json.isBlank()) {
             return List.of();
@@ -210,7 +256,6 @@ public class UsageLuaExecutor {
         }
     }
 
-    // Lua의 gift_allocations JSON 배열을 도메인 리스트로 파싱한다.
     private List<GiftAllocation> parseGiftAllocations(String json) {
         if (json == null || json.isBlank()) {
             return List.of();
@@ -235,7 +280,6 @@ public class UsageLuaExecutor {
         }
     }
 
-    // Lua 반환값(Object/byte[])을 문자열로 정규화한다.
     private String toStr(Object o) {
         if (o == null) {
             return null;
@@ -246,7 +290,6 @@ public class UsageLuaExecutor {
         return o.toString();
     }
 
-    // Lua 반환값을 long 값으로 변환한다.
     private long toLong(Object o) {
         String s = toStr(o);
         if (s == null || s.isBlank()) {


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-370

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #78 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- UsageLuaExecutor에 단계별 메트릭 추가
- hotspot.usage.lua.total (Lua executor 전체 시간)
- hotspot.usage.lua.redis.execute (Redis EVAL 실행 구간 시간)
- hotspot.usage.lua.parse (Lua 결과 파싱 시간)
- hotspot.usage.lua.status{status=ok|dup|invalid_bytes} 카운터 추가
- UsageEventHandler에 단계별 메트릭 추가
- hotspot.usage.handler.total (핸들러 전체 시간)
- hotspot.usage.handler.lua (Lua 실행 시간)
- hotspot.usage.handler.outbox (outbox/applied entity 생성 시간)
- hotspot.usage.handler.enqueue (writer queue enqueue 시간)

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
